### PR TITLE
reserved token beneficiary per tier

### DIFF
--- a/contracts/JBTieredLimitedNFTRewardDataSource.sol
+++ b/contracts/JBTieredLimitedNFTRewardDataSource.sol
@@ -327,7 +327,6 @@ contract JBTieredLimitedNFTRewardDataSource is
     if (address(tokenUriResolver) != address(0)) return tokenUriResolver.getUri(_tokenId);
 
     // Return the token URI for the token's tier.
-    // return tiers[tierIdOfToken(_tokenId)].tokenUri;
     return _decodeIpfs(tierData[tierIdOfToken(_tokenId)].tokenUri);
   }
 
@@ -422,11 +421,16 @@ contract JBTieredLimitedNFTRewardDataSource is
     // Increment the number of reserved tokens minted.
     numberOfReservesMintedFor[_tierId] += _count;
 
+    // Get a reference to the beneficiary.
+    address _benenficary = _data.reservedTokenBeneficiary == address(0)
+      ? reservedTokenBeneficiary
+      : _data.reservedTokenBeneficiary;
+
     for (uint256 _i; _i < _count; ) {
       // Mint the tokens.
-      uint256 _tokenId = _mintForTier(_tierId, _data, reservedTokenBeneficiary);
+      uint256 _tokenId = _mintForTier(_tierId, _data, _benenficary);
 
-      emit MintReservedToken(_tokenId, _tierId, reservedTokenBeneficiary, msg.sender);
+      emit MintReservedToken(_tokenId, _tierId, _benenficary, msg.sender);
 
       unchecked {
         ++_i;

--- a/contracts/JBTieredLimitedNFTRewardDataSource.sol
+++ b/contracts/JBTieredLimitedNFTRewardDataSource.sol
@@ -531,7 +531,19 @@ contract JBTieredLimitedNFTRewardDataSource is
       uint256 _tierId = _currentNumberOfTiers + _i;
 
       // Pack the tier data.
-      uint256 _packedTierData;
+
+      // contribution floor in bits 0-79.
+      uint256 _packedTierData = _tier.contributionFloor;
+      // locked until in bits 80-127.
+      _packedTierData |= _tier.lockedUntil << 80;
+      // remaining quantity in bits 128-175.
+      _packedTierData |= _tier.remainingQuantity << 128;
+      // initial quantity in bits 176-223.
+      _packedTierData |= _tier.initialQuantity << 176;
+      // voting units in bits 224-239.
+      _packedTierData |= _tier.votingUnits << 224;
+      // reserved rate in bits 240-255.
+      _packedTierData |= _tier.reservedRate << 240;
 
       // Add the tier with the iterative ID.
       _packedPropertiesOf[_tierId] = _packedTierData;

--- a/contracts/JBTieredLimitedNFTRewardDataSourceProjectDeployer.sol
+++ b/contracts/JBTieredLimitedNFTRewardDataSourceProjectDeployer.sol
@@ -190,7 +190,7 @@ contract JBTieredLimitedNFTRewardDataSourceProjectDeployer is
         _deployTieredNFTRewardDataSourceData.contractUri,
         _deployTieredNFTRewardDataSourceData.baseUri,
         _deployTieredNFTRewardDataSourceData.owner,
-        _deployTieredNFTRewardDataSourceData.tierData,
+        _deployTieredNFTRewardDataSourceData.tiers,
         _deployTieredNFTRewardDataSourceData.reservedTokenBeneficiary
       )
     );

--- a/contracts/forge-test/Deployer_Unit.t.sol
+++ b/contracts/forge-test/Deployer_Unit.t.sol
@@ -134,17 +134,17 @@ contract TestJBTieredLimitedNFTRewardDataSourceProjectDeployer is Test {
     JBGroupedSplits[] memory groupedSplits;
     JBFundAccessConstraints[] memory fundAccessConstraints;
     IJBPaymentTerminal[] memory terminals;
-    JBNFTRewardTierData[] memory tierData = new JBNFTRewardTierData[](10);
+    JBNFTRewardTierParams[] memory tiers = new JBNFTRewardTierParams[](10);
 
     for (uint256 i; i < 10; i++) {
-      tierData[i] = JBNFTRewardTierData({
+      tiers[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
         initialQuantity: uint40(100),
         votingUnits: uint16(0),
         reservedRate: uint16(0),
-        tokenUri: tokenUris[i]
+        encodedIPFSUri: tokenUris[i]
       });
     }
 
@@ -156,7 +156,7 @@ contract TestJBTieredLimitedNFTRewardDataSourceProjectDeployer is Test {
       contractUri: contractUri,
       baseUri: baseUri,
       owner: owner,
-      tierData: tierData,
+      tiers: tiers,
       shouldMintByDefault: false,
       reservedTokenBeneficiary: reserveBeneficiary
     });

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -324,20 +324,20 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     }
 
     // Add 1 new tier
-    JBNFTRewardTierData[] memory _tierDataToAdd = new JBNFTRewardTierData[](1);
-    _tierDataToAdd[0] = JBNFTRewardTierData({
+    JBNFTRewardTierParams[] memory _tiersToAdd = new JBNFTRewardTierParams[](1);
+    _tiersToAdd[0] = JBNFTRewardTierParams({
       contributionFloor: _payAmount,
       lockedUntil: uint48(0),
       remainingQuantity: uint40(100),
       initialQuantity: uint40(100),
       votingUnits: uint16(0),
       reservedRate: uint16(0),
-      tokenUri: tokenUris[0]
+      encodedIPFSUri: tokenUris[0]
     });
 
     // Remove all the existing tiers and add a new one at the previous paid price
     vm.prank(_projectOwner);
-    _delegate.adjustTiers(_tierDataToAdd, _tiersToRemove);
+    _delegate.adjustTiers(_tiersToAdd, _tiersToRemove);
 
     // Mint the new NFT and make sure that it is the new tier
     // vm.expectEmit(false, true, false, false);
@@ -376,17 +376,17 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       JBLaunchProjectData memory launchProjectData
     )
   {
-    JBNFTRewardTierData[] memory tierData = new JBNFTRewardTierData[](10);
+    JBNFTRewardTierParams[] memory tiers = new JBNFTRewardTierParams[](10);
 
     for (uint256 i; i < 10; i++) {
-      tierData[i] = JBNFTRewardTierData({
+      tiers[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(10),
         initialQuantity: uint40(10),
         votingUnits: uint16(0),
         reservedRate: uint16(0),
-        tokenUri: tokenUris[i]
+        encodedIPFSUri: tokenUris[i]
       });
     }
 
@@ -398,7 +398,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       contractUri: contractUri,
       baseUri: baseUri,
       owner: _projectOwner,
-      tierData: tierData,
+      tiers: tiers,
       shouldMintByDefault: _shouldMintByDefault,
       reservedTokenBeneficiary: reserveBeneficiary
     });

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -51,7 +51,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     'Qma5atSTeoKJkcXe2R7gdmcvPvLJLkh2jd4cDZeM1wnFgK'
   ];
 
-  JBNFTRewardTierData[] tierData;
+  JBNFTRewardTierParams[] tiers;
 
   JBTieredLimitedNFTRewardDataSource delegate;
 
@@ -89,8 +89,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     // Create 10 tiers, each with 100 tokens available to mint
     for (uint256 i; i < 10; i++) {
-      tierData.push(
-        JBNFTRewardTierData({
+      tiers.push(
+        JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
           remainingQuantity: uint40(100),
@@ -111,7 +111,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       contractUri,
       baseUri,
       owner,
-      tierData,
+      tiers,
       reserveBeneficiary
     );
   }
@@ -119,18 +119,18 @@ contract TestJBTieredNFTRewardDelegate is Test {
   function testJBTieredNFTRewardDelegate_tiers_returnsAllTiers(uint8 numberOfTiers) public {
     vm.assume(numberOfTiers > 0 && numberOfTiers < 30);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](numberOfTiers);
+    JBNFTRewardTierParams[] memory _tiers = new JBNFTRewardTierParams[](numberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](numberOfTiers);
 
     for (uint256 i; i < numberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tiers[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
         initialQuantity: uint40(100),
         votingUnits: uint16(0),
         reservedRate: uint16(0),
-        tokenUri: tokenUris[0]
+        encodedIPFSUri: tokenUris[0]
       });
 
       _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -51,7 +51,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     'Qma5atSTeoKJkcXe2R7gdmcvPvLJLkh2jd4cDZeM1wnFgK'
   ];
 
-  JBNFTRewardTierParams[] tiers;
+  JBNFTRewardTierParams[] tierParams;
 
   JBTieredLimitedNFTRewardDataSource delegate;
 
@@ -89,7 +89,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     // Create 10 tiers, each with 100 tokens available to mint
     for (uint256 i; i < 10; i++) {
-      tiers.push(
+      tierParams.push(
         JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
@@ -111,7 +111,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       contractUri,
       baseUri,
       owner,
-      tiers,
+      tierParams,
       reserveBeneficiary
     );
   }
@@ -119,7 +119,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
   function testJBTieredNFTRewardDelegate_tiers_returnsAllTiers(uint8 numberOfTiers) public {
     vm.assume(numberOfTiers > 0 && numberOfTiers < 30);
 
-    JBNFTRewardTierParams[] memory _tiers = new JBNFTRewardTierParams[](numberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](numberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](numberOfTiers);
 
     for (uint256 i; i < numberOfTiers; i++) {
@@ -133,7 +133,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         encodedIPFSUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -145,13 +145,13 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    // Avoid having difference due to the reverse order of the tiers array in _addTierData
+    // Avoid having difference due to the reverse order of the tiers array in _addTierParams
     for (uint256 i; i < numberOfTiers; i++) {
-      _delegate.ForTest_setTier(i + 1, _tierData[i]);
+      _delegate.ForTest_setTier(i + 1, _tierParams[i]);
     }
 
     assertTrue(_isIn(_delegate.tiers(), _tiers));
@@ -164,11 +164,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
   ) public {
     vm.assume(numberOfTiers > 0 && numberOfTiers < 30);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](numberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](numberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](numberOfTiers);
 
     for (uint256 i; i < numberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -178,7 +178,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -190,13 +190,13 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    // Avoid having difference due to the reverse order of the tiers array in _addTierData
+    // Avoid having difference due to the reverse order of the tiers array in _addTierParams
     for (uint256 i; i < numberOfTiers; i++) {
-      _delegate.ForTest_setTier(i + 1, _tierData[i]);
+      _delegate.ForTest_setTier(i + 1, _tierParams[i]);
     }
 
     // Check: correct tier, if exist?
@@ -205,7 +205,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     else
       assertEq( // empty tier if not?
         _delegate.tier(givenTier),
-        JBNFTRewardTier({id: givenTier, data: JBNFTRewardTierData(0, 0, 0, 0, 0, 0, 0)})
+        JBNFTRewardTier({id: givenTier, data: JBNFTRewardTierParams(0, 0, 0, 0, 0, 0, 0)})
       );
   }
 
@@ -214,10 +214,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
   {
     vm.assume(numberOfTiers > 0 && numberOfTiers < 30);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](numberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](numberOfTiers);
 
     for (uint256 i; i < numberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -237,14 +237,14 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
     for (uint256 i; i < numberOfTiers; i++) {
       _delegate.ForTest_setTier(
         i + 1,
-        JBNFTRewardTierData({
+        JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
           remainingQuantity: uint40(100 - (i + 1)),
@@ -265,10 +265,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
   ) public {
     vm.assume(numberOfTiers > 0 && numberOfTiers < 30);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](numberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](numberOfTiers);
 
     for (uint256 i; i < numberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -288,7 +288,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
@@ -309,11 +309,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     uint256 reservedMinted = 1;
     uint256 reservedRate = 4000;
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](10);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](10);
 
     // Temp tiers, will get overwritten later
     for (uint256 i; i < 10; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -333,14 +333,14 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
     for (uint256 i; i < 10; i++) {
       _delegate.ForTest_setTier(
         i + 1,
-        JBNFTRewardTierData({
+        JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
           remainingQuantity: uint40(initialQuantity - totalMinted),
@@ -372,11 +372,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
           reservedMinted
       );
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](10);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](10);
 
     // Temp tiers, will get overwritten later
     for (uint256 i; i < 10; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -396,14 +396,14 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
     for (uint256 i; i < 10; i++) {
       _delegate.ForTest_setTier(
         i + 1,
-        JBNFTRewardTierData({
+        JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
           remainingQuantity: uint40(initialQuantity - totalMinted),
@@ -436,10 +436,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
   ) public {
     vm.assume(numberOfTiers > 0 && numberOfTiers < 30);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](numberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](numberOfTiers);
 
     for (uint256 i; i < numberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -459,7 +459,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
@@ -502,7 +502,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        tierData,
+        tierParams,
         reserveBeneficiary
       );
 
@@ -523,10 +523,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
   {
     vm.assume(holder != address(0));
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](10);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](10);
 
-    for (uint256 i; i < _tierData.length; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+    for (uint256 i; i < _tierParams.length; i++) {
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -546,11 +546,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    for (uint256 i = 1; i <= _tierData.length; i++) {
+    for (uint256 i = 1; i <= _tierParams.length; i++) {
       uint256 tokenId = _generateTokenId(i, 1);
 
       _delegate.ForTest_setOwnerOf(tokenId, holder);
@@ -575,7 +575,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        tierData,
+        tierParams,
         reserveBeneficiary
       );
 
@@ -600,7 +600,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        tierData,
+        tierParams,
         reserveBeneficiary
       );
 
@@ -622,7 +622,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        tierData,
+        tierParams,
         reserveBeneficiary
       );
 
@@ -635,11 +635,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(nbTiers < 10);
 
     // Create new tiers array
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](nbTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](nbTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](nbTiers);
 
     for (uint256 i; i < nbTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80(i * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -649,7 +649,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[i]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     JBTieredLimitedNFTRewardDataSource _delegate = new JBTieredLimitedNFTRewardDataSource(
@@ -661,7 +661,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       contractUri,
       baseUri,
       owner,
-      _tierData,
+      _tierParams,
       reserveBeneficiary
     );
 
@@ -685,9 +685,9 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(errorIndex < nbTiers);
 
     // Create new tiers array
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](nbTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](nbTiers);
     for (uint256 i; i < nbTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80(i * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -698,7 +698,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       });
     }
 
-    _tierData[errorIndex].initialQuantity = 0;
+    _tierParams[errorIndex].initialQuantity = 0;
 
     // Expect the error at i+1 (as the floor is now smaller than i)
     vm.expectRevert(abi.encodeWithSignature('NO_QUANTITY()'));
@@ -711,19 +711,23 @@ contract TestJBTieredNFTRewardDelegate is Test {
       contractUri,
       baseUri,
       owner,
-      _tierData,
+      _tierParams,
       reserveBeneficiary
     );
   }
 
-  function testJBTieredNFTRewardDelegate_mintReservesFor_mintReservedToken() public {
+  function testJBTieredNFTRewardDelegate_mintReservesFor_mintReservedTokenForTheCorrectBeneficiary(
+    uint8 _offset
+  ) public {
     // 120 are minted, 1 out of these is reserved, meaning 119 non-reserved are minted. The reservedRate is 40% (4000/10000)
     // meaning there are 47 total reserved to mint, 1 being already minted, 46 are outstanding
     uint256 initialQuantity = 200;
     uint256 totalMinted = 120;
     uint256 reservedMinted = 1;
     uint256 reservedRate = 4000;
-    uint256 nbTiers = 3;
+    uint256 nbTiers = 5;
+
+    vm.assume(_offset < nbTiers);
 
     vm.mockCall(
       mockJBProjects,
@@ -731,18 +735,19 @@ contract TestJBTieredNFTRewardDelegate is Test {
       abi.encode(owner)
     );
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](nbTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](nbTiers);
 
     // Temp tiers, will get overwritten later (pass the constructor check)
     for (uint256 i; i < nbTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
         initialQuantity: uint40(100),
         votingUnits: uint16(0),
         reservedRate: uint16(0),
-        tokenUri: tokenUris[i]
+        tokenUri: tokenUris[i],
+        reservedTokenBeneficiary: owner
       });
     }
 
@@ -755,27 +760,45 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
     for (uint256 i; i < nbTiers; i++) {
-      _delegate.ForTest_setTier(
-        i + 1,
-        JBNFTRewardTierData({
-          contributionFloor: uint80((i + 1) * 10),
-          lockedUntil: uint48(0),
-          remainingQuantity: uint40(initialQuantity - totalMinted),
-          initialQuantity: uint40(initialQuantity),
-          votingUnits: uint16(0),
-          reservedRate: uint16(reservedRate),
-          tokenUri: tokenUris[i]
-        })
-      );
+      if (i != _offset)
+        _delegate.ForTest_setTier(
+          i + 1,
+          JBNFTRewardTierParams({
+            contributionFloor: uint80((i + 1) * 10),
+            lockedUntil: uint48(0),
+            remainingQuantity: uint40(initialQuantity - totalMinted),
+            initialQuantity: uint40(initialQuantity),
+            votingUnits: uint16(0),
+            reservedRate: uint16(reservedRate),
+            tokenUri: tokenUris[i],
+            reservedTokenBeneficiary: address(0)
+          })
+        ); // Set a tier-specific reserved beneficiary
+      else
+        _delegate.ForTest_setTier(
+          i + 1,
+          JBNFTRewardTierParams({
+            contributionFloor: uint80((i + 1) * 10),
+            lockedUntil: uint48(0),
+            remainingQuantity: uint40(initialQuantity - totalMinted),
+            initialQuantity: uint40(initialQuantity),
+            votingUnits: uint16(0),
+            reservedRate: uint16(reservedRate),
+            tokenUri: tokenUris[i],
+            reservedTokenBeneficiary: owner
+          })
+        );
 
       _delegate.ForTest_setReservesMintedFor(i + 1, reservedMinted);
     }
 
+    uint256 ownerTokenCounter;
+    uint256 reserveBeneficiaryTokenCounter;
     for (uint256 tier = 1; tier <= nbTiers; tier++) {
       uint256 mintable = _delegate.numberOfReservedTokensOutstandingFor(tier);
 
@@ -784,7 +807,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         emit MintReservedToken(
           _generateTokenId(tier, totalMinted + token),
           tier,
-          reserveBeneficiary,
+          tier == (_offset + 1) ? owner : reserveBeneficiary,
           owner
         );
       }
@@ -792,9 +815,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
       vm.prank(owner);
       _delegate.mintReservesFor(tier, mintable);
 
-      // Check balance
-      assertEq(_delegate.balanceOf(reserveBeneficiary), mintable * tier);
+      if (tier == (_offset + 1)) ownerTokenCounter += mintable;
+      else reserveBeneficiaryTokenCounter += mintable;
     }
+    // Check balance
+    assertEq(_delegate.balanceOf(owner), ownerTokenCounter);
+    assertEq(_delegate.balanceOf(reserveBeneficiary), reserveBeneficiaryTokenCounter);
   }
 
   function testJBTieredNFTRewardDelegate_setReservedTokenBeneficiary() public {
@@ -840,10 +866,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
     uint256 reservedMinted = 1;
     uint256 reservedRate = 4000;
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](10);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](10);
 
     for (uint256 i; i < 10; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -863,14 +889,14 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
     for (uint256 i; i < 10; i++) {
       _delegate.ForTest_setTier(
         i + 1,
-        JBNFTRewardTierData({
+        JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
           remainingQuantity: uint40(initialQuantity - totalMinted),
@@ -904,11 +930,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(initialNumberOfTiers < 15);
     vm.assume(numberTiersToAdd > 0 && numberTiersToAdd < 15);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](initialNumberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](initialNumberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](initialNumberOfTiers);
 
     for (uint256 i; i < initialNumberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -918,7 +944,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -930,15 +956,15 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    JBNFTRewardTierData[] memory _tierDataToAdd = new JBNFTRewardTierData[](numberTiersToAdd);
+    JBNFTRewardTierParams[] memory _tierParamsToAdd = new JBNFTRewardTierParams[](numberTiersToAdd);
     JBNFTRewardTier[] memory _tiersAdded = new JBNFTRewardTier[](numberTiersToAdd);
 
     for (uint256 i; i < numberTiersToAdd; i++) {
-      _tierDataToAdd[i] = JBNFTRewardTierData({
+      _tierParamsToAdd[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 100),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -948,11 +974,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierDataToAdd[i]});
+      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierParamsToAdd[i]});
     }
 
     vm.prank(owner);
-    _delegate.adjustTiers(_tierDataToAdd, new uint256[](0));
+    _delegate.adjustTiers(_tierParamsToAdd, new uint256[](0));
 
     JBNFTRewardTier[] memory _storedTiers = _delegate.tiers();
 
@@ -972,11 +998,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(initialNumberOfTiers > 0 && initialNumberOfTiers < 15);
     vm.assume(numberTiersToRemove > 0 && numberTiersToRemove < initialNumberOfTiers);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](initialNumberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](initialNumberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](initialNumberOfTiers);
 
     for (uint256 i; i < initialNumberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -986,7 +1012,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -998,7 +1024,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
@@ -1006,7 +1032,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     uint256[] memory _tiersToRemove = new uint256[](numberTiersToRemove);
 
-    JBNFTRewardTierData[] memory _tierDataRemaining = new JBNFTRewardTierData[](
+    JBNFTRewardTierParams[] memory _tierParamsRemaining = new JBNFTRewardTierParams[](
       initialNumberOfTiers - numberTiersToRemove
     );
     JBNFTRewardTier[] memory _tiersRemaining = new JBNFTRewardTier[](
@@ -1016,7 +1042,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     for (uint256 i; i < initialNumberOfTiers; i++) {
       if (i >= numberTiersToRemove) {
         uint256 _arrayIndex = i - numberTiersToRemove;
-        _tierDataRemaining[_arrayIndex] = JBNFTRewardTierData({
+        _tierParamsRemaining[_arrayIndex] = JBNFTRewardTierParams({
           contributionFloor: uint80((i + 1) * 10),
           lockedUntil: uint48(0),
           remainingQuantity: uint40(100),
@@ -1028,13 +1054,13 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
         _tiersRemaining[_arrayIndex] = JBNFTRewardTier({
           id: i + 1,
-          data: _tierDataRemaining[_arrayIndex]
+          data: _tierParamsRemaining[_arrayIndex]
         });
       } else _tiersToRemove[i] = i + 1;
     }
 
     vm.prank(owner);
-    _delegate.adjustTiers(new JBNFTRewardTierData[](0), _tiersToRemove);
+    _delegate.adjustTiers(new JBNFTRewardTierParams[](0), _tiersToRemove);
 
     JBNFTRewardTier[] memory _storedTiers = _delegate.tiers();
 
@@ -1060,11 +1086,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(initialNumberOfTiers < 30);
     vm.assume(numberTiersToAdd > 0);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](initialNumberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](initialNumberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](initialNumberOfTiers);
 
     for (uint256 i; i < initialNumberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -1074,7 +1100,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -1086,15 +1112,15 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    JBNFTRewardTierData[] memory _tierDataToAdd = new JBNFTRewardTierData[](numberTiersToAdd);
+    JBNFTRewardTierParams[] memory _tierParamsToAdd = new JBNFTRewardTierParams[](numberTiersToAdd);
     JBNFTRewardTier[] memory _tiersAdded = new JBNFTRewardTier[](numberTiersToAdd);
 
     for (uint256 i; i < numberTiersToAdd; i++) {
-      _tierDataToAdd[i] = JBNFTRewardTierData({
+      _tierParamsToAdd[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 100),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -1104,12 +1130,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierDataToAdd[i]});
+      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierParamsToAdd[i]});
     }
 
     vm.expectRevert(abi.encodeWithSignature('VOTING_UNITS_NOT_ALLOWED()'));
     vm.prank(owner);
-    _delegate.adjustTiers(_tierDataToAdd, new uint256[](0));
+    _delegate.adjustTiers(_tierParamsToAdd, new uint256[](0));
   }
 
   function testJBTieredNFTRewardDelegate_adjustTiers_revertIfAddingWithReservedRate(
@@ -1120,11 +1146,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(initialNumberOfTiers < 30);
     vm.assume(numberTiersToAdd > 0);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](initialNumberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](initialNumberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](initialNumberOfTiers);
 
     for (uint256 i; i < initialNumberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -1134,7 +1160,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -1146,15 +1172,15 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    JBNFTRewardTierData[] memory _tierDataToAdd = new JBNFTRewardTierData[](numberTiersToAdd);
+    JBNFTRewardTierParams[] memory _tierParamsToAdd = new JBNFTRewardTierParams[](numberTiersToAdd);
     JBNFTRewardTier[] memory _tiersAdded = new JBNFTRewardTier[](numberTiersToAdd);
 
     for (uint256 i; i < numberTiersToAdd; i++) {
-      _tierDataToAdd[i] = JBNFTRewardTierData({
+      _tierParamsToAdd[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 100),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -1164,12 +1190,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierDataToAdd[i]});
+      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierParamsToAdd[i]});
     }
 
     vm.expectRevert(abi.encodeWithSignature('RESERVED_RATE_NOT_ALLOWED()'));
     vm.prank(owner);
-    _delegate.adjustTiers(_tierDataToAdd, new uint256[](0));
+    _delegate.adjustTiers(_tierParamsToAdd, new uint256[](0));
   }
 
   function testJBTieredNFTRewardDelegate_adjustTiers_revertIfEmptyQuantity(
@@ -1180,11 +1206,11 @@ contract TestJBTieredNFTRewardDelegate is Test {
     vm.assume(initialNumberOfTiers < 30);
     vm.assume(numberTiersToAdd > 0);
 
-    JBNFTRewardTierData[] memory _tierData = new JBNFTRewardTierData[](initialNumberOfTiers);
+    JBNFTRewardTierParams[] memory _tierParams = new JBNFTRewardTierParams[](initialNumberOfTiers);
     JBNFTRewardTier[] memory _tiers = new JBNFTRewardTier[](initialNumberOfTiers);
 
     for (uint256 i; i < initialNumberOfTiers; i++) {
-      _tierData[i] = JBNFTRewardTierData({
+      _tierParams[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 10),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -1194,7 +1220,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierData[i]});
+      _tiers[i] = JBNFTRewardTier({id: i + 1, data: _tierParams[i]});
     }
 
     ForTest_JBTieredLimitedNFTRewardDataSource _delegate = new ForTest_JBTieredLimitedNFTRewardDataSource(
@@ -1206,15 +1232,15 @@ contract TestJBTieredNFTRewardDelegate is Test {
         contractUri,
         baseUri,
         owner,
-        _tierData,
+        _tierParams,
         reserveBeneficiary
       );
 
-    JBNFTRewardTierData[] memory _tierDataToAdd = new JBNFTRewardTierData[](numberTiersToAdd);
+    JBNFTRewardTierParams[] memory _tierParamsToAdd = new JBNFTRewardTierParams[](numberTiersToAdd);
     JBNFTRewardTier[] memory _tiersAdded = new JBNFTRewardTier[](numberTiersToAdd);
 
     for (uint256 i; i < numberTiersToAdd; i++) {
-      _tierDataToAdd[i] = JBNFTRewardTierData({
+      _tierParamsToAdd[i] = JBNFTRewardTierParams({
         contributionFloor: uint80((i + 1) * 100),
         lockedUntil: uint48(0),
         remainingQuantity: uint40(100),
@@ -1224,12 +1250,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenUri: tokenUris[0]
       });
 
-      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierDataToAdd[i]});
+      _tiersAdded[i] = JBNFTRewardTier({id: _tiers.length + (i + 1), data: _tierParamsToAdd[i]});
     }
 
     vm.expectRevert(abi.encodeWithSignature('NO_QUANTITY()'));
     vm.prank(owner);
-    _delegate.adjustTiers(_tierDataToAdd, new uint256[](0));
+    _delegate.adjustTiers(_tierParamsToAdd, new uint256[](0));
   }
 
   // -- delegate actions --
@@ -1253,7 +1279,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, tierData[0].contributionFloor - 1, 0, 0), // 1 wei below the minimum amount
+        JBTokenAmount(JBTokens.ETH, tierParams[0].contributionFloor - 1, 0, 0), // 1 wei below the minimum amount
         0,
         msg.sender,
         false,
@@ -1298,7 +1324,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, tierData[0].contributionFloor + 10, 0, 0), // 10 above the floor
+        JBTokenAmount(JBTokens.ETH, tierParams[0].contributionFloor + 10, 0, 0), // 10 above the floor
         0,
         msg.sender,
         false,
@@ -1347,7 +1373,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         0,
         JBTokenAmount(
           JBTokens.ETH,
-          tierData[0].contributionFloor * 2 + tierData[1].contributionFloor,
+          tierParams[0].contributionFloor * 2 + tierParams[1].contributionFloor,
           0,
           0
         ),
@@ -1408,7 +1434,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     );
 
     // Make sure a new NFT was minted if amount >= contribution floor
-    if (_amount >= tierData[0].contributionFloor) {
+    if (_amount >= tierParams[0].contributionFloor) {
       assertEq(_totalSupplyBeforePay + 1, delegate.totalSupply());
 
       // Correct tier has been minted?
@@ -1450,7 +1476,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _toRemove[0] = 1;
 
     vm.prank(owner);
-    delegate.adjustTiers(new JBNFTRewardTierData[](0), _toRemove);
+    delegate.adjustTiers(new JBNFTRewardTierParams[](0), _toRemove);
 
     vm.expectRevert(abi.encodeWithSignature('TIER_REMOVED()'));
     vm.prank(mockTerminalAddress);
@@ -1461,7 +1487,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         0,
         JBTokenAmount(
           JBTokens.ETH,
-          tierData[0].contributionFloor * 2 + tierData[1].contributionFloor,
+          tierParams[0].contributionFloor * 2 + tierParams[1].contributionFloor,
           0,
           0
         ),
@@ -1480,7 +1506,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
   function testJBTieredNFTRewardDelegate_didPay_revertIfNonExistingTier(uint8 _invalidTier)
     external
   {
-    vm.assume(_invalidTier > tierData.length);
+    vm.assume(_invalidTier > tierParams.length);
 
     // Mock the directory call
     vm.mockCall(
@@ -1510,7 +1536,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _toRemove[0] = 1;
 
     vm.prank(owner);
-    delegate.adjustTiers(new JBNFTRewardTierData[](0), _toRemove);
+    delegate.adjustTiers(new JBNFTRewardTierParams[](0), _toRemove);
 
     vm.expectRevert(abi.encodeWithSignature('INVALID_TIER()'));
     vm.prank(mockTerminalAddress);
@@ -1521,7 +1547,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         0,
         JBTokenAmount(
           JBTokens.ETH,
-          tierData[0].contributionFloor * 2 + tierData[1].contributionFloor,
+          tierParams[0].contributionFloor * 2 + tierParams[1].contributionFloor,
           0,
           0
         ),
@@ -1574,7 +1600,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         0,
         JBTokenAmount(
           JBTokens.ETH,
-          tierData[0].contributionFloor * 2 + tierData[1].contributionFloor - 1,
+          tierParams[0].contributionFloor * 2 + tierParams[1].contributionFloor - 1,
           0,
           0
         ),
@@ -1600,7 +1626,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       abi.encode(true)
     );
 
-    uint256 _supplyLeft = tierData[0].initialQuantity;
+    uint256 _supplyLeft = tierParams[0].initialQuantity;
     while (true) {
       uint256 _totalSupplyBeforePay = delegate.totalSupply();
 
@@ -1631,7 +1657,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
           msg.sender,
           projectId,
           0,
-          JBTokenAmount(JBTokens.ETH, tierData[0].contributionFloor, 0, 0),
+          JBTokenAmount(JBTokens.ETH, tierParams[0].contributionFloor, 0, 0),
           0,
           msg.sender,
           false,
@@ -1834,7 +1860,7 @@ contract ForTest_JBTieredLimitedNFTRewardDataSource is JBTieredLimitedNFTRewardD
     string memory _contractUri,
     string memory _baseUri,
     address _owner,
-    JBNFTRewardTierData[] memory _tierData,
+    JBNFTRewardTierParams[] memory _tierParams,
     address _reserveBeneficiary
   )
     JBTieredLimitedNFTRewardDataSource(
@@ -1846,13 +1872,13 @@ contract ForTest_JBTieredLimitedNFTRewardDataSource is JBTieredLimitedNFTRewardD
       _contractUri,
       _baseUri,
       _owner,
-      _tierData,
+      _tierParams,
       _reserveBeneficiary
     )
   {}
 
-  function ForTest_setTier(uint256 index, JBNFTRewardTierData calldata newTier) public {
-    tierData[index] = newTier;
+  function ForTest_setTier(uint256 index, JBNFTRewardTierParams calldata newTier) public {
+    tierParams[index] = newTier;
   }
 
   function ForTest_setBalanceOf(

--- a/contracts/interfaces/IJBTieredLimitedNFTRewardDataSource.sol
+++ b/contracts/interfaces/IJBTieredLimitedNFTRewardDataSource.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.6;
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBProjects.sol';
 import './../structs/JBNFTRewardTierData.sol';
 import './../structs/JBNFTRewardTier.sol';
+import '../structs/JBDeployTieredNFTRewardDataSourceData.sol';
 
 interface IJBTieredLimitedNFTRewardDataSource {
   event Mint(
@@ -46,10 +47,13 @@ interface IJBTieredLimitedNFTRewardDataSource {
 
   function tiers() external view returns (JBNFTRewardTier[] memory tiers);
 
+  function tierReservedTokenBeneficiary(uint256 _tier) external view returns (address);
+
   function reservedTokenBeneficiary() external view returns (address);
 
   function adjustTiers(
     JBNFTRewardTierData[] memory _tierDataToAdd,
+    bytes32[] memory _tokenUris,
     uint256[] memory _tierIdsToRemove
   ) external;
 

--- a/contracts/interfaces/IJBTieredLimitedNFTRewardDataSource.sol
+++ b/contracts/interfaces/IJBTieredLimitedNFTRewardDataSource.sol
@@ -47,12 +47,10 @@ interface IJBTieredLimitedNFTRewardDataSource {
 
   function tiers() external view returns (JBNFTRewardTier[] memory tiers);
 
-  function tierReservedTokenBeneficiary(uint256 _tier) external view returns (address);
-
   function reservedTokenBeneficiary() external view returns (address);
 
   function adjustTiers(
-    JBNFTRewardTierParams[] memory _tierDataToAdd,
+    JBNFTRewardTierParams[] memory _tiersToAdd,
     uint256[] memory _tierIdsToRemove
   ) external;
 

--- a/contracts/interfaces/IJBTieredLimitedNFTRewardDataSource.sol
+++ b/contracts/interfaces/IJBTieredLimitedNFTRewardDataSource.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.6;
 
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBProjects.sol';
-import './../structs/JBNFTRewardTierData.sol';
+import './../structs/JBNFTRewardTierParams.sol';
 import './../structs/JBNFTRewardTier.sol';
 import '../structs/JBDeployTieredNFTRewardDataSourceData.sol';
 
@@ -23,7 +23,7 @@ interface IJBTieredLimitedNFTRewardDataSource {
     address caller
   );
 
-  event AddTier(uint256 indexed tierId, JBNFTRewardTierData data, address caller);
+  event AddTier(uint256 indexed tierId, JBNFTRewardTierParams tier, address caller);
 
   event RemoveTier(uint256 indexed tierId, address caller);
 
@@ -43,7 +43,7 @@ interface IJBTieredLimitedNFTRewardDataSource {
 
   function tierIdOfToken(uint256 _tokenId) external view returns (uint256);
 
-  function tier(uint256 _id) external view returns (JBNFTRewardTier memory _tier);
+  function tierWith(uint256 _id) external view returns (JBNFTRewardTier memory _tier);
 
   function tiers() external view returns (JBNFTRewardTier[] memory tiers);
 
@@ -52,8 +52,7 @@ interface IJBTieredLimitedNFTRewardDataSource {
   function reservedTokenBeneficiary() external view returns (address);
 
   function adjustTiers(
-    JBNFTRewardTierData[] memory _tierDataToAdd,
-    bytes32[] memory _tokenUris,
+    JBNFTRewardTierParams[] memory _tierDataToAdd,
     uint256[] memory _tierIdsToRemove
   ) external;
 

--- a/contracts/structs/JBDeployTieredNFTRewardDataSourceData.sol
+++ b/contracts/structs/JBDeployTieredNFTRewardDataSourceData.sol
@@ -26,7 +26,5 @@ struct JBDeployTieredNFTRewardDataSourceData {
   address owner;
   JBNFTRewardTierParams[] tiers;
   bool shouldMintByDefault;
-  address reservedTokenDefaultBeneficiary;
-  bytes32[] tokenUri;
-  address[] reserveBeneficiary;
+  address reservedTokenBeneficiary;
 }

--- a/contracts/structs/JBDeployTieredNFTRewardDataSourceData.sol
+++ b/contracts/structs/JBDeployTieredNFTRewardDataSourceData.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.6;
 
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBDirectory.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBTokenUriResolver.sol';
-import './JBNFTRewardTierData.sol';
+import './JBNFTRewardTierParams.sol';
 
 /**
   @member directory The directory of terminals and controllers for projects.
@@ -12,7 +12,7 @@ import './JBNFTRewardTierData.sol';
   @member tokenUriResolver A contract responsible for resolving the token URI for each token ID.
   @member contractUri A URI where contract metadata can be found. 
   @member owner The address that should own this contract.
-  @member tierData The tier data according to which token distribution will be made. 
+  @member tiers The tier data according to which token distribution will be made. 
   @member shouldMintByDefault A flag indicating if contributions should mint NFTs if a tier's treshold is passed even if the tier ID isn't specified. 
   @member reservedTokenBeneficiary The address receiving the reserved token
 */
@@ -24,7 +24,7 @@ struct JBDeployTieredNFTRewardDataSourceData {
   string contractUri;
   string baseUri;
   address owner;
-  JBNFTRewardTierData[] tierData;
+  JBNFTRewardTierParams[] tiers;
   bool shouldMintByDefault;
   address reservedTokenDefaultBeneficiary;
   bytes32[] tokenUri;

--- a/contracts/structs/JBDeployTieredNFTRewardDataSourceData.sol
+++ b/contracts/structs/JBDeployTieredNFTRewardDataSourceData.sol
@@ -26,5 +26,7 @@ struct JBDeployTieredNFTRewardDataSourceData {
   address owner;
   JBNFTRewardTierData[] tierData;
   bool shouldMintByDefault;
-  address reservedTokenBeneficiary;
+  address reservedTokenDefaultBeneficiary;
+  bytes32[] tokenUri;
+  address[] reserveBeneficiary;
 }

--- a/contracts/structs/JBNFTRewardTier.sol
+++ b/contracts/structs/JBNFTRewardTier.sol
@@ -1,13 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
-import './JBNFTRewardTierData.sol';
-
 /**
   @member id The tier's ID.
-  @member data The data describing the tier's properties.
+  @member contributionFloor The minimum contribution to qualify for this tier.
+  @member lockedUntil The time up to which this tier cannot be removed or paused.
+  @member remainingQuantity Remaining number of tokens in this tier. Together with idCeiling this enables for consecutive, increasing token ids to be issued to contributors.
+  @member initialQuantity The initial `remainingAllowance` value when the tier was set.
+  @member votingUnits The amount of voting significance to give this tier compared to others.
+  @memver reservedRate The number of minted tokens needed in the tier to allow for minting another reserved token.
+  @member reservedRateBeneficiary The beneificary of the reserved tokens for this tier.
+  @member encodedIPFSUri The URI to use for each token within the tier.
 */
 struct JBNFTRewardTier {
   uint256 id;
-  JBNFTRewardTierData data;
+  uint256 contributionFloor;
+  uint256 lockedUntil;
+  uint256 remainingQuantity;
+  uint256 initialQuantity;
+  uint256 votingUnits;
+  uint256 reservedRate;
+  address reservedTokenBeneficiary;
+  bytes32 encodedIPFSUri;
 }

--- a/contracts/structs/JBNFTRewardTierData.sol
+++ b/contracts/structs/JBNFTRewardTierData.sol
@@ -9,6 +9,7 @@ pragma solidity 0.8.6;
   @member votingUnits The amount of voting significance to give this tier compared to others.
   @memver reservedRate The number of minted tokens needed in the tier to allow for minting another reserved token.
   @member tokenUri The URI to use for each token within the tier.
+  @member reservedRateBeneficiary The beneificary of the reserved tokens for this tier.
 */
 struct JBNFTRewardTierData {
   uint80 contributionFloor;
@@ -18,4 +19,5 @@ struct JBNFTRewardTierData {
   uint16 votingUnits;
   uint16 reservedRate;
   bytes32 tokenUri;
+  address reservedTokenBeneficiary;
 }

--- a/contracts/structs/JBNFTRewardTierData.sol
+++ b/contracts/structs/JBNFTRewardTierData.sol
@@ -18,6 +18,5 @@ struct JBNFTRewardTierData {
   uint48 initialQuantity;
   uint16 votingUnits;
   uint16 reservedRate;
-  bytes32 tokenUri;
-  address reservedTokenBeneficiary;
+  bool useTierReservedBeneficiary;
 }

--- a/contracts/structs/JBNFTRewardTierParams.sol
+++ b/contracts/structs/JBNFTRewardTierParams.sol
@@ -8,15 +8,16 @@ pragma solidity 0.8.6;
   @member initialQuantity The initial `remainingAllowance` value when the tier was set.
   @member votingUnits The amount of voting significance to give this tier compared to others.
   @memver reservedRate The number of minted tokens needed in the tier to allow for minting another reserved token.
-  @member tokenUri The URI to use for each token within the tier.
   @member reservedRateBeneficiary The beneificary of the reserved tokens for this tier.
+  @member encodedIPFSUri The URI to use for each token within the tier.
 */
-struct JBNFTRewardTierData {
-  uint80 contributionFloor;
-  uint48 lockedUntil;
-  uint48 remainingQuantity;
-  uint48 initialQuantity;
-  uint16 votingUnits;
-  uint16 reservedRate;
-  bool useTierReservedBeneficiary;
+struct JBNFTRewardTierParams {
+  uint256 contributionFloor;
+  uint256 lockedUntil;
+  uint256 remainingQuantity;
+  uint256 initialQuantity;
+  uint256 votingUnits;
+  uint256 reservedRate;
+  address reservedTokenBeneficiary;
+  bytes32 encodedIPFSUri;
 }

--- a/contracts/structs/JBStoredNFTRewardTier.sol
+++ b/contracts/structs/JBStoredNFTRewardTier.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+/**
+  @member contributionFloor The minimum contribution to qualify for this tier.
+  @member lockedUntil The time up to which this tier cannot be removed or paused.
+  @member remainingQuantity Remaining number of tokens in this tier. Together with idCeiling this enables for consecutive, increasing token ids to be issued to contributors.
+  @member initialQuantity The initial `remainingAllowance` value when the tier was set.
+  @member votingUnits The amount of voting significance to give this tier compared to others.
+  @memver reservedRate The number of minted tokens needed in the tier to allow for minting another reserved token.
+*/
+struct JBStoredNFTRewardTier {
+  uint80 contributionFloor;
+  uint48 lockedUntil;
+  uint48 remainingQuantity;
+  uint48 initialQuantity;
+  uint16 votingUnits;
+  uint16 reservedRate;
+}


### PR DESCRIPTION
open q:
if tierData.reservedTokenBeneficiary is the 0 address, does it still get "stored" and cost additional storage per tier? i.e any sense in storing the array as packed values in private uint256's with the uri and beneficiary having their own private mappings instead storing as structs?