### PR TITLE
Feature/credits

### DIFF
--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -507,8 +507,11 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     // Make sure the contribution is being made in the expected token.
     if (_data.amount.token != contributionToken) return;
 
+    // Keep a reference to the amount of credits the beneficiary already has.
+    uint256 _credits = creditsOf[_data.beneficiary];
+
     // Set the leftover amount as the initial value, including any credits the beneficiary might already have.
-    uint256 _leftoverAmount = _data.amount.value + creditsOf[_data.beneficiary];
+    uint256 _leftoverAmount = _data.amount.value + _credits;
 
     // Keep a reference to a flag indicating if a mint is expected from discretionary funds. Defaults to false, meaning to mint is expected.
     bool _expectMintFromExtraFunds;
@@ -557,7 +560,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
         // Increment the leftover amount.
         creditsOf[_data.beneficiary] = _leftoverAmount;
       }
-    }
+    } else if (_credits != 0) creditsOf[_data.beneficiary] = 0;
   }
 
   /** 

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -559,7 +559,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
 
         // Increment the leftover amount.
         creditsOf[_data.beneficiary] = _leftoverAmount;
-      }
+      } else if (_credits != 0) creditsOf[_data.beneficiary] = 0;
     } else if (_credits != 0) creditsOf[_data.beneficiary] = 0;
   }
 

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -66,13 +66,17 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
   */
   address public immutable override contributionToken = JBTokens.ETH;
 
+  //*********************************************************************//
+  // --------------------- public stored properties -------------------- //
+  //*********************************************************************//
+
   /** 
     @notice
     The amount that each address has paid that has not yet contribute to the minting of an NFT. 
 
     _address The address to which the credits belong.
   */
-  mapping(address => uint256) public override credits;
+  mapping(address => uint256) public override creditsOf;
 
   //*********************************************************************//
   // ------------------------- external views -------------------------- //
@@ -504,7 +508,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     if (_data.amount.token != contributionToken) return;
 
     // Set the leftover amount as the initial value, including any credits the beneficiary might already have.
-    uint256 _leftoverAmount = _data.amount.value + credits[_data.beneficiary];
+    uint256 _leftoverAmount = _data.amount.value + creditsOf[_data.beneficiary];
 
     // Keep a reference to a flag indicating if a mint is expected from discretionary funds. Defaults to false, meaning to mint is expected.
     bool _expectMintFromExtraFunds;
@@ -539,19 +543,20 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     }
 
     // If there are funds leftover, mint the best available with it.
-    if (_leftoverAmount != 0)
+    if (_leftoverAmount != 0) {
       _leftoverAmount = _mintBestAvailableTier(
         _leftoverAmount,
         _data.beneficiary,
         _expectMintFromExtraFunds
       );
 
-    if (_leftoverAmount != 0) {
-      // Make sure there are no leftover funds after minting if not expected.
-      if (_dontOverspend) revert OVERSPENDING();
+      if (_leftoverAmount != 0) {
+        // Make sure there are no leftover funds after minting if not expected.
+        if (_dontOverspend) revert OVERSPENDING();
 
-      // Increment the leftover amount.
-      credits[_data.beneficiary] = _leftoverAmount;
+        // Increment the leftover amount.
+        creditsOf[_data.beneficiary] = _leftoverAmount;
+      }
     }
   }
 

--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -53,6 +53,8 @@ interface IJBTiered721Delegate {
 
   function contractURI() external view returns (string memory);
 
+  function credits(address _address) external view returns (uint256);
+
   function firstOwnerOf(uint256 _tokenId) external view returns (address);
 
   function getTierDelegate(address _account, uint256 _tier) external view returns (address);

--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -53,7 +53,7 @@ interface IJBTiered721Delegate {
 
   function contractURI() external view returns (string memory);
 
-  function credits(address _address) external view returns (uint256);
+  function creditsOf(address _address) external view returns (uint256);
 
   function firstOwnerOf(uint256 _tokenId) external view returns (address);
 


### PR DESCRIPTION
allows partial payments towards an NFT reward tier. 

useful for projects that route payouts to other projects, which may not amount to the full tier floor each time `distribute` is called.