### PR TITLE
Feature/prices

### DIFF
--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -335,6 +335,10 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
 
       // Mint for the tier.
       mintReservesFor(_data.tierId, _data.count);
+
+      unchecked {
+        ++_i;
+      }
     }
   }
 

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -71,13 +71,13 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     @notice
     The currency that is accepted when minting tier NFTs. 
   */
-  uint256 public immutable override pricingCurrency = 1;
+  uint256 public immutable override pricingCurrency;
 
   /** 
     @notice
     The currency that is accepted when minting tier NFTs. 
   */
-  uint256 public immutable override pricingDecimals = 18;
+  uint256 public immutable override pricingDecimals;
 
   //*********************************************************************//
   // --------------------- public stored properties -------------------- //

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -10,6 +10,7 @@ import './interfaces/IJBTiered721Delegate.sol';
 import './libraries/JBIpfsDecoder.sol';
 import './libraries/JBTiered721FundingCycleMetadataResolver.sol';
 import './structs/JBTiered721Flags.sol';
+import './structs/JB721PricingParams.sol';
 
 /**
   @title
@@ -68,15 +69,15 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
 
   /** 
     @notice
-    The currency that is accepted when minting NFTs. 
+    The currency that is accepted when minting tier NFTs. 
   */
-  uint256 public immutable override contributionCurrency = 1;
+  uint256 public immutable override pricingCurrency = 1;
 
   /** 
     @notice
-    The currency that is accepted when minting NFTs. 
+    The currency that is accepted when minting tier NFTs. 
   */
-  uint256 public immutable override contributionDecimals = 18;
+  uint256 public immutable override pricingDecimals = 18;
 
   //*********************************************************************//
   // --------------------- public stored properties -------------------- //
@@ -263,11 +264,10 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     @param _name The name of the token.
     @param _symbol The symbol that the token should be represented by.
     @param _fundingCycleStore A contract storing all funding cycle configurations.
-    @param _prices A contract that exposes price feeds.
     @param _baseUri A URI to use as a base for full token URIs.
     @param _tokenUriResolver A contract responsible for resolving the token URI for each token ID.
     @param _contractUri A URI where contract metadata can be found. 
-    @param _tiers The tiers according to which token distribution will be made. Must be passed in order of contribution floor, with implied increasing value.
+    @param _pricing The tier pricing according to which token distribution will be made. Must be passed in order of contribution floor, with implied increasing value.
     @param _store A contract that stores the NFT's data.
     @param _flags A set of flags that help define how this contract works.
   */
@@ -277,17 +277,18 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     string memory _name,
     string memory _symbol,
     IJBFundingCycleStore _fundingCycleStore,
-    IJBPrices _prices,
     string memory _baseUri,
     IJBTokenUriResolver _tokenUriResolver,
     string memory _contractUri,
-    JB721TierParams[] memory _tiers,
+    JB721PricingParams memory _pricing,
     IJBTiered721DelegateStore _store,
     JBTiered721Flags memory _flags
   ) JB721Delegate(_projectId, _directory, _name, _symbol) EIP712(_name, '1') {
     fundingCycleStore = _fundingCycleStore;
     store = _store;
-    prices = _prices;
+    pricingCurrency = _pricing.currency;
+    pricingDecimals = _pricing.decimals;
+    prices = _pricing.prices;
 
     // Store the base URI if provided.
     if (bytes(_baseUri).length != 0) _store.recordSetBaseUri(_baseUri);
@@ -300,7 +301,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
       _store.recordSetTokenUriResolver(_tokenUriResolver);
 
     // Record adding the provided tiers.
-    if (_tiers.length > 0) _store.recordAddTiers(_tiers);
+    if (_pricing.tiers.length > 0) _store.recordAddTiers(_pricing.tiers);
 
     // Set the locked reserved token change preference if needed.
     if (_flags.lockReservedTokenChanges)
@@ -520,13 +521,15 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
   */
   function _processPayment(JBDidPayData calldata _data) internal override {
     // Normalize the currency.
-    uint256 _value = _data.amount.currency == contributionCurrency
-      ? _data.amount.value
-      : PRBMath.mulDiv(
+    uint256 _value;
+    if (_data.amount.currency == contributionCurrency) _value = _data.amount.value;
+    else if (prices != address(0))
+      _value = PRBMath.mulDiv(
         _data.amount.value,
         _data.amount.decimals,
         prices.priceFor(_data.amount.currency, contributionCurrency, contributionDecimals)
       );
+    else return;
 
     // Keep a reference to the amount of credits the beneficiary already has.
     uint256 _credits = creditsOf[_data.beneficiary];

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -526,8 +526,8 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
     else if (prices != IJBPrices(address(0)))
       _value = PRBMath.mulDiv(
         _data.amount.value,
-        _data.amount.decimals,
-        prices.priceFor(_data.amount.currency, pricingCurrency, pricingDecimals)
+        10**pricingDecimals,
+        prices.priceFor(_data.amount.currency, pricingCurrency, _data.amount.decimals)
       );
     else return;
 

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -522,12 +522,12 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Votes, Owna
   function _processPayment(JBDidPayData calldata _data) internal override {
     // Normalize the currency.
     uint256 _value;
-    if (_data.amount.currency == contributionCurrency) _value = _data.amount.value;
-    else if (prices != address(0))
+    if (_data.amount.currency == pricingCurrency) _value = _data.amount.value;
+    else if (prices != IJBPrices(address(0)))
       _value = PRBMath.mulDiv(
         _data.amount.value,
         _data.amount.decimals,
-        prices.priceFor(_data.amount.currency, contributionCurrency, contributionDecimals)
+        prices.priceFor(_data.amount.currency, pricingCurrency, pricingDecimals)
       );
     else return;
 

--- a/contracts/JBTiered721DelegateDeployer.sol
+++ b/contracts/JBTiered721DelegateDeployer.sol
@@ -49,7 +49,7 @@ contract JBTiered721DelegateDeployer is IJBTiered721DelegateDeployer {
       _deployTiered721DelegateData.baseUri,
       _deployTiered721DelegateData.tokenUriResolver,
       _deployTiered721DelegateData.contractUri,
-      _deployTiered721DelegateData.tiers,
+      _deployTiered721DelegateData.pricing,
       _deployTiered721DelegateData.store,
       _deployTiered721DelegateData.flags
     );

--- a/contracts/forge-test/Deployer_Unit.t.sol
+++ b/contracts/forge-test/Deployer_Unit.t.sol
@@ -152,7 +152,12 @@ contract TestJBTiered721DelegateProjectDeployer is Test {
       tokenUriResolver: IJBTokenUriResolver(mockTokenUriResolver),
       contractUri: contractUri,
       owner: owner,
-      tiers: tierParams,
+      pricing: JB721PricingParams({
+        tiers: tierParams,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       reservedTokenBeneficiary: reserveBeneficiary,
       store: store,
       flags: JBTiered721Flags({lockReservedTokenChanges: true, lockVotingUnitChanges: true})

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -251,7 +251,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       _generateTokenId(highestTier, 1),
       highestTier,
       _beneficiary,
-      NFTRewardDeployerData.tiers[highestTier - 1].contributionFloor,
+      NFTRewardDeployerData.pricing.tiers[highestTier - 1].contributionFloor,
       address(_jbETHPaymentTerminal) // msg.sender
     );
 
@@ -294,7 +294,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     );
 
     // _payAmount has to be at least the lowest tier
-    vm.assume(_payAmount >= NFTRewardDeployerData.tiers[0].contributionFloor);
+    vm.assume(_payAmount >= NFTRewardDeployerData.pricing.tiers[0].contributionFloor);
 
     // Pay and mint an NFT
     vm.deal(_user, _payAmount);
@@ -371,8 +371,8 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     );
 
     // _tier has to be a valid tier
-    vm.assume(_tier < NFTRewardDeployerData.tiers.length);
-    uint256 _payAmount = NFTRewardDeployerData.tiers[_tier].contributionFloor;
+    vm.assume(_tier < NFTRewardDeployerData.pricing.tiers.length);
+    uint256 _payAmount = NFTRewardDeployerData.pricing.tiers[_tier].contributionFloor;
 
     vm.prank(_user);
     _delegate.setTierDelegate(_user, _tier + 1);
@@ -396,16 +396,16 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     );
 
     // Assert that the user received the votingUnits
-    assertEq(_delegate.getVotes(_user), NFTRewardDeployerData.tiers[_tier].votingUnits);
+    assertEq(_delegate.getVotes(_user), NFTRewardDeployerData.pricing.tiers[_tier].votingUnits);
     assertEq(
       _delegate.getTierVotes(_user, _tier + 1),
-      NFTRewardDeployerData.tiers[_tier].votingUnits
+      NFTRewardDeployerData.pricing.tiers[_tier].votingUnits
     );
 
     uint256 _frenExpectedVotes = 0;
     // Have the user delegate to themselves
     if (_recipientDelegated) {
-      _frenExpectedVotes = NFTRewardDeployerData.tiers[_tier].votingUnits;
+      _frenExpectedVotes = NFTRewardDeployerData.pricing.tiers[_tier].votingUnits;
 
       vm.prank(_userFren);
       _delegate.setTierDelegate(_userFren, _tier + 1);
@@ -446,8 +446,8 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     );
 
     // _tier has to be a valid tier
-    vm.assume(_tier < NFTRewardDeployerData.tiers.length);
-    uint256 _payAmount = NFTRewardDeployerData.tiers[_tier].contributionFloor;
+    vm.assume(_tier < NFTRewardDeployerData.pricing.tiers.length);
+    uint256 _payAmount = NFTRewardDeployerData.pricing.tiers[_tier].contributionFloor;
 
     // Delegate NFT to fren
     vm.prank(_user);
@@ -484,10 +484,10 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     }
 
     // Assert that the user received the votingUnits
-    assertEq(_delegate.getVotes(_user), NFTRewardDeployerData.tiers[_tier].votingUnits);
+    assertEq(_delegate.getVotes(_user), NFTRewardDeployerData.pricing.tiers[_tier].votingUnits);
     assertEq(
       _delegate.getTierVotes(_user, _tier + 1),
-      NFTRewardDeployerData.tiers[_tier].votingUnits
+      NFTRewardDeployerData.pricing.tiers[_tier].votingUnits
     );
 
     // Delegate to the users fren
@@ -501,10 +501,10 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     assertEq(_delegate.getTierVotes(_user, _tier + 1), 0);
 
     // Assert that fren received the voting units
-    assertEq(_delegate.getVotes(_userFren), NFTRewardDeployerData.tiers[_tier].votingUnits);
+    assertEq(_delegate.getVotes(_userFren), NFTRewardDeployerData.pricing.tiers[_tier].votingUnits);
     assertEq(
       _delegate.getTierVotes(_userFren, _tier + 1),
-      NFTRewardDeployerData.tiers[_tier].votingUnits
+      NFTRewardDeployerData.pricing.tiers[_tier].votingUnits
     );
   }
 
@@ -738,7 +738,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     ) = createData();
 
     uint256 tier = 10;
-    uint256 floor = NFTRewardDeployerData.tiers[tier - 1].contributionFloor;
+    uint256 floor = NFTRewardDeployerData.pricing.tiers[tier - 1].contributionFloor;
 
     uint256 projectId = deployer.launchProjectFor(
       _projectOwner,
@@ -886,7 +886,12 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       tokenUriResolver: IJBTokenUriResolver(address(0)),
       contractUri: contractUri,
       owner: _projectOwner,
-      tiers: tierParams,
+      pricing: JB721PricingParams({
+        tiers: tierParams,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       reservedTokenBeneficiary: reserveBeneficiary,
       store: new JBTiered721DelegateStore(),
       flags: JBTiered721Flags({lockReservedTokenChanges: false, lockVotingUnitChanges: false})

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -169,7 +169,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       baseUri,
       IJBTokenUriResolver(mockTokenUriResolver),
       contractUri,
-      tiers,
+      JB721PricingParams({tiers: tiers, currency: 1, decimals: 18, prices: IJBPrices(address(0))}),
       new JBTiered721DelegateStore(),
       JBTiered721Flags({lockReservedTokenChanges: true, lockVotingUnitChanges: true})
     );
@@ -1042,7 +1042,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
       baseUri,
       IJBTokenUriResolver(mockTokenUriResolver),
       contractUri,
-      _tierParams,
+      JB721PricingParams({
+        tiers: _tierParams,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       new JBTiered721DelegateStore(),
       JBTiered721Flags({lockReservedTokenChanges: true, lockVotingUnitChanges: true})
     );
@@ -1107,7 +1112,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       baseUri,
       IJBTokenUriResolver(mockTokenUriResolver),
       contractUri,
-      _tiers,
+      JB721PricingParams({tiers: _tiers, currency: 1, decimals: 18, prices: IJBPrices(address(0))}),
       _dataSourceStore,
       JBTiered721Flags({lockReservedTokenChanges: true, lockVotingUnitChanges: true})
     );
@@ -1491,7 +1496,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
       baseUri,
       IJBTokenUriResolver(mockTokenUriResolver),
       contractUri,
-      _tierParams,
+      JB721PricingParams({
+        tiers: _tierParams,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       IJBTiered721DelegateStore(address(_store)),
       JBTiered721Flags({lockReservedTokenChanges: false, lockVotingUnitChanges: false})
     );
@@ -1768,7 +1778,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
       baseUri,
       IJBTokenUriResolver(mockTokenUriResolver),
       contractUri,
-      _tierParams,
+      JB721PricingParams({
+        tiers: _tierParams,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       IJBTiered721DelegateStore(address(_store)),
       JBTiered721Flags({lockReservedTokenChanges: false, lockVotingUnitChanges: false})
     );
@@ -2193,7 +2208,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
       baseUri,
       IJBTokenUriResolver(mockTokenUriResolver),
       contractUri,
-      _tierParams,
+      JB721PricingParams({
+        tiers: _tierParams,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       IJBTiered721DelegateStore(address(_store)),
       JBTiered721Flags({lockReservedTokenChanges: false, lockVotingUnitChanges: false})
     );
@@ -2400,8 +2420,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor - 1, 0, 0), // 1 wei below the minimum amount
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor - 1, 18, JBCurrencies.ETH), // 1 wei below the minimum amount
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2446,8 +2466,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor + 10, 0, 0), // 10 above the floor
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor + 10, 18, JBCurrencies.ETH), // 10 above the floor
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2497,10 +2517,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
         JBTokenAmount(
           JBTokens.ETH,
           tiers[0].contributionFloor * 2 + tiers[1].contributionFloor,
-          0,
-          0
+          18,
+          JBCurrencies.ETH
         ),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2548,8 +2568,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, _amount, 0, 0),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, _amount, 18, JBCurrencies.ETH),
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2605,8 +2625,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, _amount, 0, 0),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, _amount, 18, JBCurrencies.ETH),
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         beneficiary,
         false,
@@ -2655,8 +2675,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, _amount, 0, 0),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, _amount, 18, JBCurrencies.ETH),
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         beneficiary,
         false,
@@ -2674,8 +2694,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, _amount, 0, 0),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, _amount, 18, JBCurrencies.ETH),
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         beneficiary,
         false,
@@ -2747,10 +2767,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
         JBTokenAmount(
           JBTokens.ETH,
           tiers[0].contributionFloor * 2 + tiers[1].contributionFloor,
-          0,
-          0
+          18,
+          JBCurrencies.ETH
         ),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2808,10 +2828,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
         JBTokenAmount(
           JBTokens.ETH,
           tiers[0].contributionFloor * 2 + tiers[1].contributionFloor,
-          0,
-          0
+          18,
+          JBCurrencies.ETH
         ),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2866,10 +2886,10 @@ contract TestJBTieredNFTRewardDelegate is Test {
         JBTokenAmount(
           JBTokens.ETH,
           tiers[0].contributionFloor * 2 + tiers[1].contributionFloor - 1,
-          0,
-          0
+          18,
+          JBCurrencies.ETH
         ),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2921,8 +2941,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           msg.sender,
           projectId,
           0,
-          JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor, 0, 0),
-          JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+          JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor, 18, JBCurrencies.ETH),
+          JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
           0,
           msg.sender,
           false,
@@ -2963,8 +2983,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(address(0), 0, 0, 0),
-        JBTokenAmount(address(0), 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(address(0), 0, 18, JBCurrencies.ETH),
+        JBTokenAmount(address(0), 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -2999,8 +3019,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(token, 0, 0, 0),
-        JBTokenAmount(token, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(token, 0, 18, JBCurrencies.ETH),
+        JBTokenAmount(token, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         msg.sender,
         false,
@@ -3049,8 +3069,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         msg.sender,
         projectId,
         0,
-        JBTokenAmount(JBTokens.ETH, _amount, 0, 0),
-        JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+        JBTokenAmount(JBTokens.ETH, _amount, 18, JBCurrencies.ETH),
+        JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
         0,
         beneficiary,
         false,
@@ -3144,7 +3164,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
           tokenCount: 0,
           totalSupply: 0,
           overflow: _overflow,
-          reclaimAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
+          reclaimAmount: JBTokenAmount({
+            token: address(0),
+            value: 0,
+            decimals: 18,
+            currency: JBCurrencies.ETH
+          }),
           useTotalOverflow: true,
           redemptionRate: _redemptionRate,
           memo: 'plz gib',
@@ -3249,7 +3274,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
           tokenCount: 0,
           totalSupply: 0,
           overflow: _overflow,
-          reclaimAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
+          reclaimAmount: JBTokenAmount({
+            token: address(0),
+            value: 0,
+            decimals: 18,
+            currency: JBCurrencies.ETH
+          }),
           useTotalOverflow: true,
           redemptionRate: _redemptionRate,
           memo: 'plz gib',
@@ -3345,7 +3375,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
           tokenCount: 0,
           totalSupply: 0,
           overflow: _overflow,
-          reclaimAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
+          reclaimAmount: JBTokenAmount({
+            token: address(0),
+            value: 0,
+            decimals: 18,
+            currency: JBCurrencies.ETH
+          }),
           useTotalOverflow: true,
           redemptionRate: _redemptionRate,
           memo: 'plz gib',
@@ -3377,7 +3412,12 @@ contract TestJBTieredNFTRewardDelegate is Test {
         tokenCount: _tokenCount,
         totalSupply: 0,
         overflow: 100,
-        reclaimAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
+        reclaimAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }),
         useTotalOverflow: true,
         redemptionRate: 100,
         memo: '',
@@ -3432,8 +3472,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           _holder,
           projectId,
           0,
-          JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor, 0, 0),
-          JBTokenAmount(JBTokens.ETH, 0, 0, 0), // 0 fwd to delegate
+          JBTokenAmount(JBTokens.ETH, tiers[0].contributionFloor, 18, JBCurrencies.ETH),
+          JBTokenAmount(JBTokens.ETH, 0, 18, JBCurrencies.ETH), // 0 fwd to delegate
           0,
           _holder,
           false,
@@ -3455,8 +3495,18 @@ contract TestJBTieredNFTRewardDelegate is Test {
         projectId: projectId,
         currentFundingCycleConfiguration: 1,
         projectTokenCount: 0,
-        reclaimedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
-        forwardedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}), // 0 fwd to delegate
+        reclaimedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }),
+        forwardedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }), // 0 fwd to delegate
         beneficiary: payable(_holder),
         memo: 'thy shall redeem',
         metadata: abi.encode(_tokenList)
@@ -3499,8 +3549,18 @@ contract TestJBTieredNFTRewardDelegate is Test {
         projectId: _wrongProjectId,
         currentFundingCycleConfiguration: 1,
         projectTokenCount: 0,
-        reclaimedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
-        forwardedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}), // 0 fwd to delegate
+        reclaimedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }),
+        forwardedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }), //sv 0 fwd to delegate
         beneficiary: payable(_holder),
         memo: 'thy shall redeem',
         metadata: abi.encode(_tokenList)
@@ -3535,8 +3595,18 @@ contract TestJBTieredNFTRewardDelegate is Test {
         projectId: projectId,
         currentFundingCycleConfiguration: 1,
         projectTokenCount: 0,
-        reclaimedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
-        forwardedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}), // 0 fwd to delegate
+        reclaimedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }),
+        forwardedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }), // 0 fwd to delegate
         beneficiary: payable(_holder),
         memo: 'thy shall redeem',
         metadata: abi.encode(_tokenList)
@@ -3589,8 +3659,18 @@ contract TestJBTieredNFTRewardDelegate is Test {
         projectId: projectId,
         currentFundingCycleConfiguration: 1,
         projectTokenCount: 0,
-        reclaimedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}),
-        forwardedAmount: JBTokenAmount({token: address(0), value: 0, decimals: 0, currency: 0}), // 0 fwd to delegate
+        reclaimedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }),
+        forwardedAmount: JBTokenAmount({
+          token: address(0),
+          value: 0,
+          decimals: 18,
+          currency: JBCurrencies.ETH
+        }), // 0 fwd to delegate
         beneficiary: payable(_wrongHolder),
         memo: 'thy shall redeem',
         metadata: abi.encode(_tokenList)
@@ -3810,7 +3890,7 @@ contract ForTest_JBTiered721Delegate is JBTiered721Delegate {
       _baseUri,
       _tokenUriResolver,
       _contractUri,
-      _tiers,
+      JB721PricingParams({tiers: _tiers, currency: 1, decimals: 18, prices: IJBPrices(address(0))}),
       _test_store,
       _flags
     )

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -2763,7 +2763,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     bool _dontMint;
     bool _expectMintFromExtraFunds;
-    bool _dontOverspend;
+    bool _dontOverspend = true;
     uint16[] memory _tierIdsToMint = new uint16[](3);
     _tierIdsToMint[0] = 1;
     _tierIdsToMint[1] = 1;

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -1281,6 +1281,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
       );
     }
 
+    uint256 _totalMintable; // Keep a running counter
+
     JBTiered721MintReservesForTiersData[]
       memory _reservedToMint = new JBTiered721MintReservesForTiersData[](nbTiers);
 
@@ -1295,22 +1297,25 @@ contract TestJBTieredNFTRewardDelegate is Test {
         count: mintable
       });
 
+      _totalMintable += mintable;
+
       for (uint256 token = 1; token <= mintable; token++) {
+        uint256 _tokenNonce = totalMinted + token; // Avoid stack too deep
         vm.expectEmit(true, true, true, true, address(_delegate));
         emit MintReservedToken(
-          _generateTokenId(tier, totalMinted + token),
+          _generateTokenId(tier, _tokenNonce),
           tier,
           reserveBeneficiary,
           owner
         );
       }
-
-      vm.prank(owner);
-      _delegate.mintReservesFor(_reservedToMint);
-
-      // Check balance
-      assertEq(_delegate.balanceOf(reserveBeneficiary), mintable * tier);
     }
+
+    vm.prank(owner);
+    _delegate.mintReservesFor(_reservedToMint);
+
+    // Check balance
+    assertEq(_delegate.balanceOf(reserveBeneficiary), _totalMintable);
   }
 
   function testJBTieredNFTRewardDelegate_setReservedTokenBeneficiary(address _newBeneficiary)

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -1212,6 +1212,107 @@ contract TestJBTieredNFTRewardDelegate is Test {
     }
   }
 
+  function testJBTieredNFTRewardDelegate_mintReservesFor_mintMultipleReservedToken() public {
+    // 120 are minted, 1 out of these is reserved, meaning 119 non-reserved are minted. The reservedRate is 40% (4000/10000)
+    // meaning there are 47 total reserved to mint, 1 being already minted, 46 are outstanding
+    uint256 initialQuantity = 200;
+    uint256 totalMinted = 120;
+    uint256 reservedMinted = 1;
+    uint256 reservedRate = 4000;
+    uint256 nbTiers = 3;
+
+    vm.mockCall(
+      mockJBProjects,
+      abi.encodeWithSelector(IERC721.ownerOf.selector, projectId),
+      abi.encode(owner)
+    );
+
+    JB721TierParams[] memory _tiers = new JB721TierParams[](nbTiers);
+
+    // Temp tiers, will get overwritten later (pass the constructor check)
+    for (uint256 i; i < nbTiers; i++) {
+      _tiers[i] = JB721TierParams({
+        contributionFloor: uint80((i + 1) * 10),
+        lockedUntil: uint48(0),
+        initialQuantity: uint40(100),
+        votingUnits: uint16(0),
+        reservedRate: uint16(0),
+        reservedTokenBeneficiary: reserveBeneficiary,
+        encodedIPFSUri: tokenUris[i],
+        shouldUseBeneficiaryAsDefault: false
+      });
+    }
+
+    ForTest_JBTiered721DelegateStore _ForTest_store = new ForTest_JBTiered721DelegateStore();
+    ForTest_JBTiered721Delegate _delegate = new ForTest_JBTiered721Delegate(
+      projectId,
+      IJBDirectory(mockJBDirectory),
+      name,
+      symbol,
+      IJBFundingCycleStore(mockJBFundingCycleStore),
+      baseUri,
+      IJBTokenUriResolver(mockTokenUriResolver),
+      contractUri,
+      _tiers,
+      IJBTiered721DelegateStore(address(_ForTest_store)),
+      JBTiered721Flags({lockReservedTokenChanges: false, lockVotingUnitChanges: false})
+    );
+
+    _delegate.transferOwnership(owner);
+
+    for (uint256 i; i < nbTiers; i++) {
+      _delegate.test_store().ForTest_setTier(
+        address(_delegate),
+        i + 1,
+        JBStored721Tier({
+          contributionFloor: uint80((i + 1) * 10),
+          lockedUntil: uint48(0),
+          remainingQuantity: uint40(initialQuantity - totalMinted),
+          initialQuantity: uint40(initialQuantity),
+          votingUnits: uint16(0),
+          reservedRate: uint16(reservedRate)
+        })
+      );
+
+      _delegate.test_store().ForTest_setReservesMintedFor(
+        address(_delegate),
+        i + 1,
+        reservedMinted
+      );
+    }
+
+    JBTiered721MintReservesForTiersData[]
+      memory _reservedToMint = new JBTiered721MintReservesForTiersData[](nbTiers);
+
+    for (uint256 tier = 1; tier <= nbTiers; tier++) {
+      uint256 mintable = _delegate.test_store().numberOfReservedTokensOutstandingFor(
+        address(_delegate),
+        tier
+      );
+
+      _reservedToMint[tier - 1] = JBTiered721MintReservesForTiersData({
+        tierId: tier,
+        count: mintable
+      });
+
+      for (uint256 token = 1; token <= mintable; token++) {
+        vm.expectEmit(true, true, true, true, address(_delegate));
+        emit MintReservedToken(
+          _generateTokenId(tier, totalMinted + token),
+          tier,
+          reserveBeneficiary,
+          owner
+        );
+      }
+
+      vm.prank(owner);
+      _delegate.mintReservesFor(_reservedToMint);
+
+      // Check balance
+      assertEq(_delegate.balanceOf(reserveBeneficiary), mintable * tier);
+    }
+  }
+
   function testJBTieredNFTRewardDelegate_setReservedTokenBeneficiary(address _newBeneficiary)
     public
   {

--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBFundingCycleStore.sol';
-import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBPrices.sol';
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBProjects.sol';
 import './../structs/JB721TierParams.sol';
 import './../structs/JBTiered721MintReservesForTiersData.sol';
@@ -52,9 +51,9 @@ interface IJBTiered721Delegate {
 
   function prices() external view returns (IJBPrices);
 
-  function contributionCurrency() external view returns (uint256);
+  function tierCurrency() external view returns (uint256);
 
-  function contributionDecimals() external view returns (uint256);
+  function tierDecimals() external view returns (uint256);
 
   function contractURI() external view returns (string memory);
 

--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBFundingCycleStore.sol';
+import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBPrices.sol';
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBProjects.sol';
 import './../structs/JB721TierParams.sol';
 import './../structs/JBTiered721MintReservesForTiersData.sol';

--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBFundingCycleStore.sol';
+import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBPrices.sol';
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBProjects.sol';
 import './../structs/JB721TierParams.sol';
 import './../structs/JBTiered721MintReservesForTiersData.sol';
@@ -49,7 +50,11 @@ interface IJBTiered721Delegate {
 
   function fundingCycleStore() external view returns (IJBFundingCycleStore);
 
-  function contributionToken() external view returns (address);
+  function prices() external view returns (IJBPrices);
+
+  function contributionCurrency() external view returns (uint256);
+
+  function contributionDecimals() external view returns (uint256);
 
   function contractURI() external view returns (string memory);
 

--- a/contracts/interfaces/IJBTiered721Delegate.sol
+++ b/contracts/interfaces/IJBTiered721Delegate.sol
@@ -52,9 +52,9 @@ interface IJBTiered721Delegate {
 
   function prices() external view returns (IJBPrices);
 
-  function tierCurrency() external view returns (uint256);
+  function pricingCurrency() external view returns (uint256);
 
-  function tierDecimals() external view returns (uint256);
+  function pricingDecimals() external view returns (uint256);
 
   function contractURI() external view returns (string memory);
 

--- a/contracts/scripts/LaunchProjectFor.s.sol
+++ b/contracts/scripts/LaunchProjectFor.s.sol
@@ -154,7 +154,12 @@ contract RinkebyLaunchProjectFor is Script {
       tokenUriResolver: IJBTokenUriResolver(address(0)),
       contractUri: contractUri,
       owner: _projectOwner,
-      tiers: tiers,
+      pricing: JB721PricingParams({
+        tiers: tiers,
+        currency: 1,
+        decimals: 18,
+        prices: IJBPrices(address(0))
+      }),
       reservedTokenBeneficiary: msg.sender,
       store: IJBTiered721DelegateStore(STORE),
       flags: JBTiered721Flags({lockReservedTokenChanges: true, lockVotingUnitChanges: true})

--- a/contracts/structs/JB721PricingParams.sol
+++ b/contracts/structs/JB721PricingParams.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBPrices.sol';
+import './JB721TierParams.sol';
+
+/**
+  @member tiers The tiers to set.
+  @member currency The currency that the tier contribution floors are denoted in.
+  @member decimals The number of decimals included in the tier contribution floor fixed point numbers.
+  @member prices A contract that exposes price feeds that can be used to resolved the value of a contributions that are sent in different currencies. Set to the zero address if payments must be made in `currency`.
+*/
+struct JB721PricingParams {
+  JB721TierParams[] tiers;
+  uint256 currency;
+  uint256 decimals;
+  IJBPrices prices;
+}

--- a/contracts/structs/JBDeployTiered721DelegateData.sol
+++ b/contracts/structs/JBDeployTiered721DelegateData.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.16;
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBDirectory.sol';
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBFundingCycleStore.sol';
 import '@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBTokenUriResolver.sol';
-import './JB721TierParams.sol';
+import './JB721PricingParams.sol';
 import './JBTiered721Flags.sol';
 import './../interfaces/IJBTiered721DelegateStore.sol';
 
@@ -17,7 +17,7 @@ import './../interfaces/IJBTiered721DelegateStore.sol';
   @member tokenUriResolver A contract responsible for resolving the token URI for each token ID.
   @member contractUri A URI where contract metadata can be found. 
   @member owner The address that should own this contract.
-  @member tiers The tier data according to which token distribution will be made. 
+  @member pricing The tier pricing according to which token distribution will be made. 
   @member reservedTokenBeneficiary The address receiving the reserved token
   @member store The store contract to use.
   @member flags A set of flags that help define how this contract works.
@@ -31,7 +31,7 @@ struct JBDeployTiered721DelegateData {
   IJBTokenUriResolver tokenUriResolver;
   string contractUri;
   address owner;
-  JB721TierParams[] tiers;
+  JB721PricingParams pricing;
   address reservedTokenBeneficiary;
   IJBTiered721DelegateStore store;
   JBTiered721Flags flags;


### PR DESCRIPTION
tiers passed into constructor in a new `pricing` structure, which includes the expected currency and decimals of each contribution tier, and an optional IJBPrices address that can be used to resolve discrepancies if contributions are being made in a different currency. send address(0) for this IJBPrices to bypass and force contributions to be made in the same currency as the tiers are specified in.