### PR TITLE
Adjustment/improve name

### DIFF
--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -729,15 +729,21 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
     if (_from != address(0)) {
       // Transfers must not be paused.
       if (store.flagsOf(address(this)).transfersPausable) {
-        // Get a reference to the project's current funding cycle.
-        JBFundingCycle memory _fundingCycle = fundingCycleStore.currentOf(projectId);
+        // Get a reference to the tier.
+        JB721Tier memory _tier = store.tierOfTokenId(address(this), _tokenId);
 
-        if (
-          _to != address(0) &&
-          JBTiered721FundingCycleMetadataResolver.transfersPaused(
-            (JBFundingCycleMetadataResolver.metadata(_fundingCycle))
-          )
-        ) revert TRANSFERS_PAUSED();
+        // Transfers from the tier must be pausable.
+        if (_tier.transfersPausable) {
+          // Get a reference to the project's current funding cycle.
+          JBFundingCycle memory _fundingCycle = fundingCycleStore.currentOf(projectId);
+
+          if (
+            _to != address(0) &&
+            JBTiered721FundingCycleMetadataResolver.transfersPaused(
+              (JBFundingCycleMetadataResolver.metadata(_fundingCycle))
+            )
+          ) revert TRANSFERS_PAUSED();
+        }
       }
 
       // If there's no stored first owner, and the transfer isn't originating from the zero address as expected for mints, store the first owner.

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -244,7 +244,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
       _flags.lockReservedTokenChanges ||
       _flags.lockVotingUnitChanges ||
       _flags.lockManualMintingChanges ||
-      _flags.pausable
+      _flags.transfersPausable
     ) _store.recordFlags(_flags);
 
     // Transfer ownership to the initializer.

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -728,7 +728,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
     // Transfered must not be paused when not minting or burning.
     if (_from != address(0)) {
       // Transfers must not be paused.
-      if (store.flagsOf(address(this)).pausable) {
+      if (store.flagsOf(address(this)).transfersPausable) {
         // Get a reference to the project's current funding cycle.
         JBFundingCycle memory _fundingCycle = fundingCycleStore.currentOf(projectId);
 

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -243,8 +243,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
     if (
       _flags.lockReservedTokenChanges ||
       _flags.lockVotingUnitChanges ||
-      _flags.lockManualMintingChanges ||
-      _flags.transfersPausable
+      _flags.lockManualMintingChanges
     ) _store.recordFlags(_flags);
 
     // Transfer ownership to the initializer.
@@ -727,23 +726,20 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
   ) internal virtual override {
     // Transfered must not be paused when not minting or burning.
     if (_from != address(0)) {
-      // Transfers must not be paused.
-      if (store.flagsOf(address(this)).transfersPausable) {
-        // Get a reference to the tier.
-        JB721Tier memory _tier = store.tierOfTokenId(address(this), _tokenId);
+      // Get a reference to the tier.
+      JB721Tier memory _tier = store.tierOfTokenId(address(this), _tokenId);
 
-        // Transfers from the tier must be pausable.
-        if (_tier.transfersPausable) {
-          // Get a reference to the project's current funding cycle.
-          JBFundingCycle memory _fundingCycle = fundingCycleStore.currentOf(projectId);
+      // Transfers from the tier must be pausable.
+      if (_tier.transfersPausable) {
+        // Get a reference to the project's current funding cycle.
+        JBFundingCycle memory _fundingCycle = fundingCycleStore.currentOf(projectId);
 
-          if (
-            _to != address(0) &&
-            JBTiered721FundingCycleMetadataResolver.transfersPaused(
-              (JBFundingCycleMetadataResolver.metadata(_fundingCycle))
-            )
-          ) revert TRANSFERS_PAUSED();
-        }
+        if (
+          _to != address(0) &&
+          JBTiered721FundingCycleMetadataResolver.transfersPaused(
+            (JBFundingCycleMetadataResolver.metadata(_fundingCycle))
+          )
+        ) revert TRANSFERS_PAUSED();
       }
 
       // If there's no stored first owner, and the transfer isn't originating from the zero address as expected for mints, store the first owner.

--- a/contracts/JBTiered721DelegateStore.sol
+++ b/contracts/JBTiered721DelegateStore.sol
@@ -252,7 +252,8 @@ contract JBTiered721DelegateStore is IJBTiered721DelegateStore {
           reservedRate: _storedTier.reservedRate,
           reservedTokenBeneficiary: reservedTokenBeneficiaryOf(_nft, _currentSortIndex),
           encodedIPFSUri: encodedIPFSUriOf[_nft][_currentSortIndex],
-          allowManualMint: _storedTier.allowManualMint
+          allowManualMint: _storedTier.allowManualMint,
+          transfersPausable: _storedTier.transfersPausable
         });
       }
 
@@ -291,7 +292,8 @@ contract JBTiered721DelegateStore is IJBTiered721DelegateStore {
         reservedRate: _storedTier.reservedRate,
         reservedTokenBeneficiary: reservedTokenBeneficiaryOf(_nft, _id),
         encodedIPFSUri: encodedIPFSUriOf[_nft][_id],
-        allowManualMint: _storedTier.allowManualMint
+        allowManualMint: _storedTier.allowManualMint,
+        transfersPausable: _storedTier.transfersPausable
       });
   }
 
@@ -327,7 +329,8 @@ contract JBTiered721DelegateStore is IJBTiered721DelegateStore {
         reservedRate: _storedTier.reservedRate,
         reservedTokenBeneficiary: reservedTokenBeneficiaryOf(_nft, _tierId),
         encodedIPFSUri: encodedIPFSUriOf[_nft][_tierId],
-        allowManualMint: _storedTier.allowManualMint
+        allowManualMint: _storedTier.allowManualMint,
+        transfersPausable: _storedTier.transfersPausable
       });
   }
 
@@ -692,7 +695,8 @@ contract JBTiered721DelegateStore is IJBTiered721DelegateStore {
         initialQuantity: uint40(_tierToAdd.initialQuantity),
         votingUnits: uint16(_tierToAdd.votingUnits),
         reservedRate: uint16(_tierToAdd.reservedRate),
-        allowManualMint: _tierToAdd.allowManualMint
+        allowManualMint: _tierToAdd.allowManualMint,
+        transfersPausable: _tierToAdd.transfersPausable
       });
 
       // Set the reserved token beneficiary if needed.

--- a/contracts/forge-test/Deployer_Unit.t.sol
+++ b/contracts/forge-test/Deployer_Unit.t.sol
@@ -176,8 +176,7 @@ contract TestJBTiered721DelegateProjectDeployer is Test {
       flags: JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       }),
       governanceType: JB721GovernanceType.NONE
     });

--- a/contracts/forge-test/Deployer_Unit.t.sol
+++ b/contracts/forge-test/Deployer_Unit.t.sol
@@ -177,7 +177,7 @@ contract TestJBTiered721DelegateProjectDeployer is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       }),
       governanceType: JB721GovernanceType.NONE
     });

--- a/contracts/forge-test/Deployer_Unit.t.sol
+++ b/contracts/forge-test/Deployer_Unit.t.sol
@@ -151,7 +151,8 @@ contract TestJBTiered721DelegateProjectDeployer is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+        transfersPausable: false
       });
     }
 

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -338,7 +338,8 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       reservedTokenBeneficiary: reserveBeneficiary,
       encodedIPFSUri: tokenUris[0],
       allowManualMint: false,
-      shouldUseBeneficiaryAsDefault: false
+      shouldUseBeneficiaryAsDefault: false,
+      transfersPausable: false
     });
 
     // Remove all the existing tiers and add a new one at the previous paid price
@@ -726,7 +727,8 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+        transfersPausable: false
       });
     }
 

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -752,8 +752,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       flags: JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       }),
       governanceType: JB721GovernanceType.NONE
     });

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -753,7 +753,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       }),
       governanceType: JB721GovernanceType.NONE
     });

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -194,7 +194,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       }),
       JB721GovernanceType.NONE
     );
@@ -257,7 +257,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -336,7 +336,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -420,7 +420,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -510,7 +510,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -582,7 +582,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -643,7 +643,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -717,7 +717,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -784,7 +784,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -846,7 +846,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -925,7 +925,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -984,7 +984,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1038,7 +1038,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1078,7 +1078,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1119,7 +1119,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1194,7 +1194,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1268,7 +1268,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
   }
@@ -1328,7 +1328,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1430,7 +1430,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1590,7 +1590,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1670,7 +1670,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1763,7 +1763,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1839,7 +1839,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -1915,7 +1915,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2042,7 +2042,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2199,7 +2199,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2346,7 +2346,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2385,7 +2385,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
           reservedTokenBeneficiary: _tierDataRemaining[_arrayIndex].reservedTokenBeneficiary,
           encodedIPFSUri: _tierDataRemaining[_arrayIndex].encodedIPFSUri,
           allowManualMint: _tierDataRemaining[_arrayIndex].allowManualMint,
-                transfersPausable: _tierDataRemainins[_arrayIndex].transfersPausable
+                transfersPausable: _tierDataRemaining[_arrayIndex].transfersPausable
         });
         _arrayIndex++;
       } else {
@@ -2511,7 +2511,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2618,7 +2618,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2725,7 +2725,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2834,7 +2834,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -2952,7 +2952,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -3269,7 +3269,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -3513,7 +3513,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -4103,7 +4103,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: false
+        transfersPausable: false
       })
     );
 
@@ -4217,7 +4217,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -4325,7 +4325,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -4444,7 +4444,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -4554,7 +4554,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -4679,7 +4679,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 
@@ -4870,7 +4870,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       })
     );
 

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -193,8 +193,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       }),
       JB721GovernanceType.NONE
     );
@@ -256,8 +255,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -335,8 +333,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -419,8 +416,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -509,8 +505,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -581,8 +576,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -642,8 +636,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -716,8 +709,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -783,8 +775,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -845,8 +836,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -924,8 +914,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -983,8 +972,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1037,8 +1025,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1077,8 +1064,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1118,8 +1104,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1193,8 +1178,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1267,8 +1251,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
   }
@@ -1327,8 +1310,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1429,8 +1411,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1589,8 +1570,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1669,8 +1649,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1762,8 +1741,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1838,8 +1816,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -1914,8 +1891,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2041,8 +2017,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2198,8 +2173,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2345,8 +2319,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2510,8 +2483,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2617,8 +2589,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2724,8 +2695,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2833,8 +2803,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -2951,8 +2920,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -3268,8 +3236,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -3512,8 +3479,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -4102,8 +4068,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: false
+        lockManualMintingChanges: true
       })
     );
 
@@ -4216,8 +4181,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -4324,8 +4288,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -4443,8 +4406,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -4553,8 +4515,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -4678,8 +4639,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 
@@ -4869,8 +4829,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       JBTiered721Flags({
         lockReservedTokenChanges: false,
         lockVotingUnitChanges: false,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       })
     );
 

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -119,7 +119,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           reservedTokenBeneficiary: reserveBeneficiary,
           encodedIPFSUri: tokenUris[i],
           allowManualMint: false,
-          shouldUseBeneficiaryAsDefault: false
+          shouldUseBeneficiaryAsDefault: false,
+                transfersPausable: false
         })
       );
     }
@@ -221,7 +222,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: uint16(0),
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -234,7 +236,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+              transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -293,7 +296,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: uint16(0),
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -306,7 +310,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+        transfersPausable: _tierParams[i].transfersPausable
       });
 
       if (i != firstRemovedTier - 1 && i != secondRemovedTier - 1) {
@@ -380,7 +385,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -393,7 +399,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+              transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -431,7 +438,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(_tierParams[i].initialQuantity),
           votingUnits: uint16(_tierParams[i].votingUnits),
           reservedRate: uint16(_tierParams[i].reservedRate),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
     }
@@ -452,7 +460,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           reservedRate: 0,
           reservedTokenBeneficiary: address(0),
           encodedIPFSUri: bytes32(0),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
   }
@@ -480,7 +489,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -517,7 +527,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(100),
           votingUnits: uint16(0),
           reservedRate: uint16(0),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
     }
@@ -550,7 +561,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -610,7 +622,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -647,7 +660,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(initialQuantity),
           votingUnits: uint16(0),
           reservedRate: uint16(reservedRate),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
       _delegate.test_store().ForTest_setReservesMintedFor(
@@ -682,7 +696,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -810,7 +825,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -880,7 +896,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       if (i >= firstTier && i < lastTier) {
@@ -946,7 +963,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -983,7 +1001,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(10 * i),
           votingUnits: uint16(0),
           reservedRate: uint16(0),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
 
@@ -1134,7 +1153,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -1147,7 +1167,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+              transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -1219,7 +1240,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -1285,7 +1307,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -1322,7 +1345,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(initialQuantity),
           votingUnits: uint16(0),
           reservedRate: uint16(reservedRate),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
 
@@ -1385,7 +1409,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -1422,7 +1447,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(initialQuantity),
           votingUnits: uint16(0),
           reservedRate: uint16(reservedRate),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
 
@@ -1543,7 +1569,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -1580,7 +1607,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(initialQuantity),
           votingUnits: uint16(0),
           reservedRate: uint16(reservedRate),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
 
@@ -1621,7 +1649,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
     }
 
@@ -1658,7 +1687,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(initialQuantity),
           votingUnits: uint16(0),
           reservedRate: uint16(reservedRate),
-          allowManualMint: false
+          allowManualMint: false,
+                transfersPausable: false
         })
       );
 
@@ -1709,7 +1739,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: true, // Allow this type of mint
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiersToMint[i] = uint16(i)+1;
@@ -1778,7 +1809,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: true, // Allow this type of mint
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiersToMintOne[i] = uint16(i)+1;
@@ -1857,7 +1889,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[i],
         allowManualMint: true,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiersToMint[i] = uint16(i)+1;
@@ -1967,7 +2000,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -1980,7 +2014,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+              transfersPausable: false
       });
     }
 
@@ -2025,7 +2060,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
       _tiersAdded[i] = JB721Tier({
         id: _tiers.length + (i + 1),
@@ -2037,7 +2073,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParamsToAdd[i].reservedRate,
         reservedTokenBeneficiary: _tierParamsToAdd[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParamsToAdd[i].encodedIPFSUri,
-        allowManualMint: _tierParamsToAdd[i].allowManualMint
+        allowManualMint: _tierParamsToAdd[i].allowManualMint,
+              transfersPausable: _tierParamsToAdd[i].transfersPausable
       });
       vm.expectEmit(true, true, true, true, address(_delegate));
       emit AddTier(_tiersAdded[i].id, _tierParamsToAdd[i], owner);
@@ -2127,7 +2164,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2140,7 +2178,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+              transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -2264,7 +2303,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2277,7 +2317,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+              transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -2329,7 +2370,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           reservedTokenBeneficiary: reserveBeneficiary,
           encodedIPFSUri: tokenUris[0],
           allowManualMint: false,
-          shouldUseBeneficiaryAsDefault: false
+          shouldUseBeneficiaryAsDefault: false,
+                transfersPausable: false
         });
 
         _tiersRemaining[_arrayIndex] = JB721Tier({
@@ -2342,7 +2384,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           reservedRate: _tierDataRemaining[_arrayIndex].reservedRate,
           reservedTokenBeneficiary: _tierDataRemaining[_arrayIndex].reservedTokenBeneficiary,
           encodedIPFSUri: _tierDataRemaining[_arrayIndex].encodedIPFSUri,
-          allowManualMint: _tierDataRemaining[_arrayIndex].allowManualMint
+          allowManualMint: _tierDataRemaining[_arrayIndex].allowManualMint,
+                transfersPausable: _tierDataRemainins[_arrayIndex].transfersPausable
         });
         _arrayIndex++;
       } else {
@@ -2366,7 +2409,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiersAdded[i] = JB721Tier({
@@ -2379,7 +2423,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParamsToAdd[i].reservedRate,
         reservedTokenBeneficiary: _tierParamsToAdd[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParamsToAdd[i].encodedIPFSUri,
-        allowManualMint: _tierParamsToAdd[i].allowManualMint
+        allowManualMint: _tierParamsToAdd[i].allowManualMint,
+        transfersPausable: _tierParamsToAdd[i].transfersPausable
       });
 
       vm.expectEmit(true, true, true, true, address(_delegate));
@@ -2431,7 +2476,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2444,7 +2490,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+        transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -2483,7 +2530,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiersAdded[i] = JB721Tier({
@@ -2496,7 +2544,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParamsToAdd[i].reservedRate,
         reservedTokenBeneficiary: _tierParamsToAdd[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParamsToAdd[i].encodedIPFSUri,
-        allowManualMint: _tierParamsToAdd[i].allowManualMint
+        allowManualMint: _tierParamsToAdd[i].allowManualMint,
+        transfersPausable: _tierParamsToAdd[i].transfersPausable
       });
     }
 
@@ -2534,7 +2583,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2547,7 +2597,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParam[i].reservedRate,
         reservedTokenBeneficiary: _tierParam[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParam[i].encodedIPFSUri,
-        allowManualMint: _tierParam[i].allowManualMint
+        allowManualMint: _tierParam[i].allowManualMint,
+        transfersPausable: _tierParam[i].transfersPausable
       });
     }
 
@@ -2586,7 +2637,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+              transfersPausable: false
       });
 
       _tiersAdded[i] = JB721Tier({
@@ -2599,7 +2651,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParamsToAdd[i].reservedRate,
         reservedTokenBeneficiary: _tierParamsToAdd[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParamsToAdd[i].encodedIPFSUri,
-        allowManualMint: _tierParamsToAdd[i].allowManualMint
+        allowManualMint: _tierParamsToAdd[i].allowManualMint,
+        transfersPausable: _tierParamsToAdd[i].transfersPausable
       });
     }
 
@@ -2637,7 +2690,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+        transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2650,7 +2704,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+                transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -2689,7 +2744,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                transfersPausable: false
       });
 
       _tiersAdded[i] = JB721Tier({
@@ -2702,7 +2758,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParamsToAdd[i].reservedRate,
         reservedTokenBeneficiary: _tierParamsToAdd[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParamsToAdd[i].encodedIPFSUri,
-        allowManualMint: _tierParamsToAdd[i].allowManualMint
+        allowManualMint: _tierParamsToAdd[i].allowManualMint,
+                transfersPausable: _tierParamsToAdd[i].transfersPausable
       });
     }
 
@@ -2735,7 +2792,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                        transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2748,7 +2806,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+                        transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -2858,7 +2917,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                        transfersPausable: false
       });
 
       _tiers[i] = JB721Tier({
@@ -2871,7 +2931,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: _tierParams[i].reservedRate,
         reservedTokenBeneficiary: _tierParams[i].reservedTokenBeneficiary,
         encodedIPFSUri: _tierParams[i].encodedIPFSUri,
-        allowManualMint: _tierParams[i].allowManualMint
+        allowManualMint: _tierParams[i].allowManualMint,
+                        transfersPausable: _tierParams[i].transfersPausable
       });
     }
 
@@ -3183,7 +3244,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedRate: uint16(0),
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                        transfersPausable: false
       });
     }
 
@@ -4242,7 +4304,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                                transfersPausable: false
       });
     }
 
@@ -4280,7 +4343,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(10 * i),
           votingUnits: uint16(0),
           reservedRate: uint16(0),
-          allowManualMint: false
+          allowManualMint: false,
+                                  transfersPausable: false
         })
       );
 
@@ -4359,7 +4423,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                                transfersPausable: false
       });
     }
 
@@ -4397,7 +4462,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(10 * i),
           votingUnits: uint16(0),
           reservedRate: uint16(0),
-          allowManualMint: false
+          allowManualMint: false,
+                                  transfersPausable: false
         })
       );
 
@@ -4466,7 +4532,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
         reservedTokenBeneficiary: reserveBeneficiary,
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: false
+        shouldUseBeneficiaryAsDefault: false,
+                                transfersPausable: false
       });
     }
 
@@ -4505,7 +4572,8 @@ contract TestJBTieredNFTRewardDelegate is Test {
           initialQuantity: uint40(10 * i),
           votingUnits: uint16(0),
           reservedRate: uint16(0),
-          allowManualMint: false
+          allowManualMint: false,
+                                  transfersPausable: false
         })
       );
 
@@ -5118,7 +5186,8 @@ contract ForTest_JBTiered721DelegateStore is
         reservedRate: _storedTier.reservedRate,
         reservedTokenBeneficiary: reservedTokenBeneficiaryOf(_nft, _currentSortIndex),
         encodedIPFSUri: encodedIPFSUriOf[_nft][_currentSortIndex],
-        allowManualMint: _storedTier.allowManualMint
+        allowManualMint: _storedTier.allowManualMint,
+                                transfersPausable: _storedTier.transfersPausable
       });
 
       // Set the next sort index.

--- a/contracts/scripts/LaunchProjectFor.s.sol
+++ b/contracts/scripts/LaunchProjectFor.s.sol
@@ -168,7 +168,7 @@ contract RinkebyLaunchProjectFor is Script {
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
         lockManualMintingChanges: true,
-        pausable: true
+        transfersPausable: true
       }),
       governanceType: JB721GovernanceType.NONE
     });

--- a/contracts/scripts/LaunchProjectFor.s.sol
+++ b/contracts/scripts/LaunchProjectFor.s.sol
@@ -167,8 +167,7 @@ contract RinkebyLaunchProjectFor is Script {
       flags: JBTiered721Flags({
         lockReservedTokenChanges: true,
         lockVotingUnitChanges: true,
-        lockManualMintingChanges: true,
-        transfersPausable: true
+        lockManualMintingChanges: true
       }),
       governanceType: JB721GovernanceType.NONE
     });

--- a/contracts/scripts/LaunchProjectFor.s.sol
+++ b/contracts/scripts/LaunchProjectFor.s.sol
@@ -142,7 +142,8 @@ contract RinkebyLaunchProjectFor is Script {
         reservedTokenBeneficiary: address(0),
         encodedIPFSUri: 0x7D5A99F603F231D53A4F39D1521F98D2E8BB279CF29BEBFD0687DC98458E7F89,
         allowManualMint: false,
-        shouldUseBeneficiaryAsDefault: true
+        shouldUseBeneficiaryAsDefault: true,
+        transfersPausable: false
       });
     }
 

--- a/contracts/structs/JB721Tier.sol
+++ b/contracts/structs/JB721Tier.sol
@@ -12,6 +12,7 @@ pragma solidity ^0.8.16;
   @member reservedRateBeneficiary The beneificary of the reserved tokens for this tier.
   @member encodedIPFSUri The URI to use for each token within the tier.
   @member allowManualMint A flag indicating if the contract's owner can mint from this tier on demand.
+  @member transfersPausable A flag indicating if transfers from this tier can be pausable. 
 */
 struct JB721Tier {
   uint256 id;
@@ -24,4 +25,5 @@ struct JB721Tier {
   address reservedTokenBeneficiary;
   bytes32 encodedIPFSUri;
   bool allowManualMint;
+  bool transfersPausable;
 }

--- a/contracts/structs/JB721TierParams.sol
+++ b/contracts/structs/JB721TierParams.sol
@@ -11,6 +11,7 @@ pragma solidity ^0.8.0;
   @member encodedIPFSUri The URI to use for each token within the tier.
   @member allowManualMint A flag indicating if the contract's owner can mint from this tier on demand.
   @member shouldUseBeneficiaryAsDefault A flag indicating if the `reservedTokenBeneficiary` should be stored as the default beneficiary for all tiers.
+  @member transfersPausable A flag indicating if transfers from this tier can be pausable. 
 */
 struct JB721TierParams {
   uint256 contributionFloor;
@@ -22,4 +23,5 @@ struct JB721TierParams {
   bytes32 encodedIPFSUri;
   bool allowManualMint;
   bool shouldUseBeneficiaryAsDefault;
+  bool transfersPausable;
 }

--- a/contracts/structs/JBStored721Tier.sol
+++ b/contracts/structs/JBStored721Tier.sol
@@ -9,6 +9,7 @@ pragma solidity ^0.8.0;
   @member votingUnits The amount of voting significance to give this tier compared to others.
   @member reservedRate The number of minted tokens needed in the tier to allow for minting another reserved token.
   @member allowManualMint A flag indicating if the contract's owner can mint from this tier on demand.
+  @member transfersPausable A flag indicating if transfers from this tier can be pausable. 
 */
 struct JBStored721Tier {
   uint80 contributionFloor;
@@ -18,4 +19,5 @@ struct JBStored721Tier {
   uint16 votingUnits;
   uint16 reservedRate;
   bool allowManualMint;
+  bool transfersPausable;
 }

--- a/contracts/structs/JBTiered721Flags.sol
+++ b/contracts/structs/JBTiered721Flags.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.0;
   @member lockReservedTokenChanges A flag indicating if reserved tokens can change over time by adding new tiers with a reserved rate.
   @member lockVotingUnitChanges A flag indicating if voting unit expectations can change over time by adding new tiers with voting units.
   @member lockManualMintingChanges A flag indicating if manual minting expectations can change over time by adding new tiers with manual minting.
-  @member pausable A flag indicating if the NFT's can be pausable via a funding cycle flag.
+  @member transfersPausable A flag indicating if the NFT transfers can be pausable via a funding cycle flag.
 */
 struct JBTiered721Flags {
   bool lockReservedTokenChanges;
   bool lockVotingUnitChanges;
   bool lockManualMintingChanges;
-  bool pausable;
+  bool transfersPausable;
 }

--- a/contracts/structs/JBTiered721Flags.sol
+++ b/contracts/structs/JBTiered721Flags.sol
@@ -5,11 +5,9 @@ pragma solidity ^0.8.0;
   @member lockReservedTokenChanges A flag indicating if reserved tokens can change over time by adding new tiers with a reserved rate.
   @member lockVotingUnitChanges A flag indicating if voting unit expectations can change over time by adding new tiers with voting units.
   @member lockManualMintingChanges A flag indicating if manual minting expectations can change over time by adding new tiers with manual minting.
-  @member transfersPausable A flag indicating if the NFT transfers can be pausable via a funding cycle flag.
 */
 struct JBTiered721Flags {
   bool lockReservedTokenChanges;
   bool lockVotingUnitChanges;
   bool lockManualMintingChanges;
-  bool transfersPausable;
 }


### PR DESCRIPTION
tiers can prevent ever becoming non-transferable. removing the global lock flag in favor of this per-tier flag.