### PR TITLE
32 more bytes

### DIFF
--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -546,10 +546,11 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
     bool _dontOverspend;
 
     // Skip the first 32 bytes which are used by the JB protocol to pass the paying project's ID when paying from a JBSplit.
+    // Skip another 32 bytes reserved for generic extension parameters.
     // Check the 4 bytes interfaceId to verify the metadata is intended for this contract.
     if (
       _data.metadata.length > 36 &&
-      bytes4(_data.metadata[32:36]) == type(IJB721Delegate).interfaceId
+      bytes4(_data.metadata[64:68]) == type(IJB721Delegate).interfaceId
     ) {
       // Keep a reference to the flag indicating if the transaction should not mint anything.
       bool _dontMint;
@@ -558,9 +559,9 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
       uint16[] memory _tierIdsToMint;
 
       // Decode the metadata.
-      (, , _dontMint, _expectMintFromExtraFunds, _dontOverspend, _tierIdsToMint) = abi.decode(
+      (, , , _dontMint, _expectMintFromExtraFunds, _dontOverspend, _tierIdsToMint) = abi.decode(
         _data.metadata,
-        (bytes32, bytes4, bool, bool, bool, uint16[])
+        (bytes32, bytes32, bytes4, bool, bool, bool, uint16[])
       );
 
       // Don't mint if not desired.

--- a/contracts/JBTiered721Delegate.sol
+++ b/contracts/JBTiered721Delegate.sol
@@ -548,7 +548,7 @@ contract JBTiered721Delegate is IJBTiered721Delegate, JB721Delegate, Ownable {
     // Skip another 32 bytes reserved for generic extension parameters.
     // Check the 4 bytes interfaceId to verify the metadata is intended for this contract.
     if (
-      _data.metadata.length > 36 &&
+      _data.metadata.length > 68 &&
       bytes4(_data.metadata[64:68]) == type(IJB721Delegate).interfaceId
     ) {
       // Keep a reference to the flag indicating if the transaction should not mint anything.

--- a/contracts/abstract/JB721Delegate.sol
+++ b/contracts/abstract/JB721Delegate.sol
@@ -116,8 +116,9 @@ abstract contract JB721Delegate is
     if (_data.tokenCount > 0) revert UNEXPECTED_TOKEN_REDEEMED();
 
     // Check the 4 bytes interfaceId and handle the case where the metadata was not intended for this contract
+    // Skip 32 bytes reserved for generic extension parameters.
     if (
-      _data.metadata.length < 4 || bytes4(_data.metadata[0:4]) != type(IJB721Delegate).interfaceId
+      _data.metadata.length < 36 || bytes4(_data.metadata[32:36]) != type(IJB721Delegate).interfaceId
     ) {
       revert INVALID_REDEMPTION_METADATA();
     }
@@ -130,7 +131,7 @@ abstract contract JB721Delegate is
     if (_data.redemptionRate == 0) return (0, _data.memo, delegateAllocations);
 
     // Decode the metadata
-    (, uint256[] memory _decodedTokenIds) = abi.decode(_data.metadata, (bytes4, uint256[]));
+    (, , uint256[] memory _decodedTokenIds) = abi.decode(_data.metadata, (bytes32, bytes4, uint256[]));
 
     // Get a reference to the redemption rate of the provided tokens.
     uint256 _redemptionWeight = _redemptionWeightOf(_decodedTokenIds);
@@ -236,7 +237,7 @@ abstract contract JB721Delegate is
     // Process the payment.
     _processPayment(_data);
   }
-
+event Test(bytes4);
   /**
     @notice
     Part of IJBRedeemDelegate, this function gets called when the token holder redeems. It will burn the specified NFTs to reclaim from the treasury to the _data.beneficiary.
@@ -255,12 +256,13 @@ abstract contract JB721Delegate is
     ) revert INVALID_REDEMPTION_EVENT();
 
     // Check the 4 bytes interfaceId and handle the case where the metadata was not intended for this contract
+    // Skip 32 bytes reserved for generic extension parameters.
     if (
-      _data.metadata.length < 4 || bytes4(_data.metadata[0:4]) != type(IJB721Delegate).interfaceId
+      _data.metadata.length < 36 || bytes4(_data.metadata[32:36]) != type(IJB721Delegate).interfaceId
     ) revert INVALID_REDEMPTION_METADATA();
 
     // Decode the metadata.
-    (, uint256[] memory _decodedTokenIds) = abi.decode(_data.metadata, (bytes4, uint256[]));
+    (,, uint256[] memory _decodedTokenIds) = abi.decode(_data.metadata, (bytes32, bytes4, uint256[]));
 
     // Get a reference to the number of token IDs being checked.
     uint256 _numberOfTokenIds = _decodedTokenIds.length;

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -547,7 +547,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     // Craft the metadata: redeem the tokenId
     uint256[] memory redemptionId = new uint256[](1);
     redemptionId[0] = tokenId;
-    bytes memory redemptionMetadata = abi.encode(type(IJB721Delegate).interfaceId, redemptionId);
+    bytes memory redemptionMetadata = abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, redemptionId);
 
     vm.prank(_beneficiary);
     _jbETHPaymentTerminal.redeemTokensOf({
@@ -650,7 +650,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
       redemptionId[i] = tokenId;
     }
 
-    bytes memory redemptionMetadata = abi.encode(type(IJB721Delegate).interfaceId, redemptionId);
+    bytes memory redemptionMetadata = abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, redemptionId);
 
     vm.prank(_beneficiary);
     _jbETHPaymentTerminal.redeemTokensOf({

--- a/contracts/forge-test/E2E.t.sol
+++ b/contracts/forge-test/E2E.t.sol
@@ -101,6 +101,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     rawMetadata[0] = uint16(highestTier);
     bytes memory metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       false,
       false,
@@ -196,6 +197,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
 
     // Encode it to metadata
     bytes memory metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       false,
@@ -415,6 +417,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     rawMetadata[0] = uint16(highestTier); // reward tier
     bytes memory metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       false,
       false,
@@ -508,6 +511,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     uint16[] memory rawMetadata = new uint16[](1);
     rawMetadata[0] = uint16(highestTier);
     bytes memory metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       false,
@@ -603,6 +607,7 @@ contract TestJBTieredNFTRewardDelegateE2E is TestBaseWorkflow {
     for (uint256 i; i < rawMetadata.length; i++) rawMetadata[i] = uint16(tier);
 
     bytes memory metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       false,

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -3021,6 +3021,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     bytes memory _metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
       _expectMintFromExtraFunds,
@@ -3068,6 +3069,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _tierIdsToMint[2] = 2;
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -3122,6 +3124,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     uint16[] memory _tierIdsToMint = new uint16[](0);
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -3273,6 +3276,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     bytes memory _metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
       _expectMintFromExtraFunds,
@@ -3315,6 +3319,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     uint16[] memory _tierIdsToMint = new uint16[](0);
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -3364,6 +3369,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _tierIdsToMint[2] = 2;
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -3482,6 +3488,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     bytes memory _metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
       _expectMintFromExtraFunds,
@@ -3534,6 +3541,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _tierIdsToMint[2] = 2;
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -3595,6 +3603,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _tierIdsToMint[0] = _invalidTier;
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -3660,6 +3669,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     bytes memory _metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
       _expectMintFromExtraFunds,
@@ -3717,6 +3727,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
       tierSelected[0] = 1;
 
       bytes memory _metadata = abi.encode(
+        bytes32(0),
         bytes32(0),
         type(IJB721Delegate).interfaceId,
         _dontMint,
@@ -3846,6 +3857,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
 
     bytes memory _metadata = abi.encode(
       bytes32(0),
+      bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
       _expectMintFromExtraFunds,
@@ -3936,6 +3948,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _tierIdsToMint[2] = 2;
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,
@@ -4054,6 +4067,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
     _tierIdsToMint[2] = 2;
 
     bytes memory _metadata = abi.encode(
+      bytes32(0),
       bytes32(0),
       type(IJB721Delegate).interfaceId,
       _dontMint,

--- a/contracts/forge-test/NFTReward_Unit.t.sol
+++ b/contracts/forge-test/NFTReward_Unit.t.sol
@@ -4288,7 +4288,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         }), // 0 fwd to delegate
         beneficiary: payable(_holder),
         memo: 'thy shall redeem',
-        metadata: abi.encode(type(IJB721Delegate).interfaceId, _tokenToRedeem)
+        metadata: abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, _tokenToRedeem)
       })
     );
 
@@ -4398,7 +4398,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
           useTotalOverflow: true,
           redemptionRate: _redemptionRate,
           memo: 'plz gib',
-          metadata: abi.encode(type(IJB721Delegate).interfaceId, _tokenList)
+          metadata: abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, _tokenList)
         })
       );
 
@@ -4440,7 +4440,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         encodedIPFSUri: tokenUris[0],
         allowManualMint: false,
         shouldUseBeneficiaryAsDefault: false,
-                                transfersPausable: false
+        transfersPausable: false
       });
     }
 
@@ -4478,7 +4478,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
           votingUnits: uint16(0),
           reservedRate: uint16(0),
           allowManualMint: false,
-                                  transfersPausable: false
+          transfersPausable: false
         })
       );
 
@@ -4516,7 +4516,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
           useTotalOverflow: true,
           redemptionRate: _redemptionRate,
           memo: 'plz gib',
-          metadata: abi.encode(type(IJB721Delegate).interfaceId, _tokenList)
+          metadata: abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, _tokenList)
         })
       );
 
@@ -4625,7 +4625,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
           useTotalOverflow: true,
           redemptionRate: _redemptionRate,
           memo: 'plz gib',
-          metadata: abi.encode(type(IJB721Delegate).interfaceId, _tokenList)
+          metadata: abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, _tokenList)
         })
       );
 
@@ -4754,7 +4754,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         }), // 0 fwd to delegate
         beneficiary: payable(_holder),
         memo: 'thy shall redeem',
-        metadata: abi.encode(type(IJB721Delegate).interfaceId, _tokenList)
+        metadata: abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, _tokenList)
       })
     );
 
@@ -4922,7 +4922,7 @@ contract TestJBTieredNFTRewardDelegate is Test {
         }), // 0 fwd to delegate
         beneficiary: payable(_wrongHolder),
         memo: 'thy shall redeem',
-        metadata: abi.encode(type(IJB721Delegate).interfaceId, _tokenList)
+        metadata: abi.encode(bytes32(0), type(IJB721Delegate).interfaceId, _tokenList)
       })
     );
   }


### PR DESCRIPTION
Add 32 more bytes to the metadata space for generic use by other delegates _before_ the run-on metadata used for this delegate. 